### PR TITLE
Skip tests affected by Pulp issue 3875

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -39,7 +39,7 @@ from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import upload_import_unit
 
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
-from pulp_2_tests.tests.rpm.utils import set_up_module
+from pulp_2_tests.tests.rpm.utils import check_issue_3875, set_up_module
 
 
 _REPOS = {}  # e.g. {'signed': {'_href': …}}
@@ -150,6 +150,8 @@ class RequireValidKeyTestCase(_BaseTestCase):
 
         Assert no packages are copied in.
         """
+        if check_issue_3875(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/3875')
         repo = self.create_populate_repo({
             'allowed_keys': [PULP_FIXTURES_KEY_ID],
             'require_signature': True,
@@ -172,6 +174,8 @@ class RequireInvalidKeyTestCase(_BaseTestCase):
 
         Assert no packages are copied in.
         """
+        if check_issue_3875(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/3875')
         repo = self.create_populate_repo({
             'allowed_keys': ['01234567'],
             'require_signature': True,
@@ -183,6 +187,8 @@ class RequireInvalidKeyTestCase(_BaseTestCase):
 
         Assert no packages are copied in.
         """
+        if check_issue_3875(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/3875')
         repo = self.create_populate_repo({
             'allowed_keys': ['01234567'],
             'require_signature': True,
@@ -217,6 +223,8 @@ class RequireAnyKeyTestCase(_BaseTestCase):
 
         Assert no packages are copied in.
         """
+        if check_issue_3875(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/3875')
         repo = self.create_populate_repo({
             'allowed_keys': [],
             'require_signature': True,
@@ -239,6 +247,8 @@ class AllowInvalidKeyTestCase(_BaseTestCase):
 
         Assert no packages are copied in.
         """
+        if check_issue_3875(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/3875')
         repo = self.create_populate_repo({
             'allowed_keys': ['01234567'],
             'require_signature': False,

--- a/pulp_2_tests/tests/rpm/utils.py
+++ b/pulp_2_tests/tests/rpm/utils.py
@@ -103,6 +103,17 @@ def check_issue_3104(cfg):
             not selectors.bug_is_fixed(3104, cfg.pulp_version))
 
 
+def check_issue_3875(cfg):
+    """Return true if `Pulp #3875`_ affects the targeted Pulp system.
+
+    :param cfg: The Pulp system under test.
+
+    .. _Pulp #3875: https://pulp.plan.io/issues/3875
+    """
+    return (cfg.pulp_version >= Version('2.17') and
+            not selectors.bug_is_fixed(3875, cfg.pulp_version))
+
+
 def os_is_f26(cfg, pulp_host=None):
     """Tell whether the given Pulp host's OS is F26."""
     return (utils.get_os_release_id(cfg, pulp_host) == 'fedora' and


### PR DESCRIPTION
Issue title: "Traceback when RPM import fails signature check"

See: https://pulp.plan.io/issues/3875