### PR TITLE
Depend on a Pulp Smash version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'jsonschema',
         'packaging',
-        'pulp-smash',
+        'pulp-smash>=1!0.0.1,<1!1',
         'python-dateutil',
     ],
     extras_require={


### PR DESCRIPTION
This guards against new versions of Pulp Smash that introduce breaking
changes.

See: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies