### PR TITLE
Move content-specific pulp_smash constants here

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -6,6 +6,7 @@ Location: :doc:`/index` → :doc:`/tests`
 .. toctree::
 
     tests/pulp_2_tests
+    tests/pulp_2_tests.constants
     tests/pulp_2_tests.tests
     tests/pulp_2_tests.tests.docker
     tests/pulp_2_tests.tests.docker.api_v2

--- a/docs/tests/pulp_2_tests.constants.rst
+++ b/docs/tests/pulp_2_tests.constants.rst
@@ -1,0 +1,6 @@
+`pulp_2_tests.constants`
+========================
+
+Location: :doc:`/index` → :doc:`/tests` → :doc:`/tests/pulp_2_tests.constants`
+
+.. automodule:: pulp_2_tests.constants

--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -1,0 +1,554 @@
+# coding=utf-8
+"""Values usable by multiple test modules."""
+from types import MappingProxyType  # used to form an immutable dictionary
+from urllib.parse import quote_plus, urljoin
+
+from pulp_smash.constants import PULP_FIXTURES_BASE_URL
+
+
+DOCKER_IMAGE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'docker/busybox:latest.tar')
+"""The URL to a Docker image as created by ``docker save``."""
+
+DOCKER_UPSTREAM_NAME_NOLIST = 'library/busybox'
+"""The name of a Docker repository without a manifest list.
+
+:data:`DOCKER_UPSTREAM_NAME` should be used when possible. However, this
+constant is useful for backward compatibility. If Pulp is asked to sync a
+repository, and:
+
+* Pulp older than 2.14 is under test.
+* The repository is configured to sync schema v2 content.
+* The upstream repository has a manifest list.
+
+…then Pulp will break when syncing. See `Pulp #2384
+<https://pulp.plan.io/issues/2384>`_.
+"""
+
+DOCKER_UPSTREAM_NAME = 'dmage/manifest-list-test'
+"""The name of a Docker repository.
+
+This repository has several desireable properties:
+
+* It is available via both :data:`DOCKER_V1_FEED_URL` and
+  :data:`DOCKER_V2_FEED_URL`.
+* It has a manifest list, where one entry has an architecture of amd64 and an
+  os of linux. (The "latest" tag offers this.)
+* It is relatively small.
+
+This repository also has several shortcomings:
+
+* This repository isn't an official repository. It's less trustworthy, and may
+  be more likely to change with little or no notice.
+* It doesn't have a manifest list where no list entries have an architecture of
+  amd64 and an os of linux. (The "arm32v7" tag provides schema v1 content.)
+
+One can get a high-level view of the content in this repository by executing:
+
+.. code-block:: sh
+
+    curl --location --silent \
+    https://registry.hub.docker.com/v2/repositories/$this_constant/tags \
+    | python -m json.tool
+"""
+
+DOCKER_V1_FEED_URL = 'https://index.docker.io'
+"""The URL to a V1 Docker registry.
+
+This URL can be used as the "feed" property of a Pulp Docker registry.
+"""
+
+DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
+"""The URL to a V2 Docker registry.
+
+This URL can be used as the "feed" property of a Pulp Docker registry.
+"""
+
+DRPM = 'drpms/test-alpha-1.1-1_1.1-2.noarch.drpm'
+"""The path to a DRPM file in one of the DRPM repositories.
+
+This path may be joined with :data:`DRPM_SIGNED_FEED_URL` or
+:data:`DRPM_UNSIGNED_FEED_URL`.
+"""
+
+DRPM_SIGNED_FEED_COUNT = 4
+"""The number of packages available at :data:`DRPM_SIGNED_FEED_URL`."""
+
+DRPM_SIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-signed/')
+"""The URL to a signed DRPM repository."""
+
+DRPM_SIGNED_URL = urljoin(DRPM_SIGNED_FEED_URL, DRPM)
+"""The URL to a DRPM file.
+
+Built from :data:`DRPM_SIGNED_FEED_URL` and :data:`DRPM`.
+"""
+
+DRPM_UNSIGNED_FEED_COUNT = 4
+"""The number of packages available at :data:`DRPM_UNSIGNED_FEED_URL`."""
+
+DRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
+"""The URL to an unsigned DRPM repository."""
+
+DRPM_UNSIGNED_URL = urljoin(DRPM_UNSIGNED_FEED_URL, DRPM)
+"""The URL to a unsigned DRPM file.
+
+Built from :data:`DRPM_UNSIGNED_FEED_URL` and :data:`DRPM`.
+"""
+
+FILE_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file/')
+"""The URL to a file repository."""
+
+FILE_FEED_COUNT = 3
+"""The number of packages available at :data:`FILE_FEED_URL`."""
+
+FILE_LARGE_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-large/')
+"""The URL to a file repository containing a large number of files."""
+
+FILE_MANY_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-many/')
+"""The URL to a file repository containing many files."""
+
+FILE_MANY_FEED_COUNT = 250
+"""The number of packages available at :data:`FILE_MANY_FEED_URL`."""
+
+FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
+"""The URL to a file repository containing invalid and valid entries."""
+
+FILE_URL = urljoin(FILE_FEED_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE_FEED_URL`."""
+
+FILE2_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
+"""The URL to a file repository."""
+
+FILE2_URL = urljoin(FILE2_FEED_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE2_FEED_URL`."""
+
+OPENSUSE_FEED_URL = 'https://download.opensuse.org/update/leap/42.3/oss/'
+"""The URL to an openSUSE repository.
+
+The repository contains at least one erratum.
+
+.. WARNING:: This repository is large, and is served by a third party. Do not
+    sync from this repository with the "immediate" or "background" download
+    policies. Know that metadata parsing will be time-consuming.
+"""
+
+OSTREE_BRANCHES = ['rawhide', 'stable']
+"""A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
+
+.. _Importer Configuration:
+    http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
+"""
+
+OSTREE_FEED = urljoin(PULP_FIXTURES_BASE_URL, 'ostree/small/')
+"""The URL to a URL of OSTree branches. See OSTree `Importer Configuration`_.
+
+.. _Importer Configuration:
+    http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
+"""
+
+PUPPET_MODULE_1 = {
+    'author': 'pulpqe',
+    'name': 'dummypuppet',
+    'version': '0.1.0'
+}
+"""Information about a Puppet module available via Pulp Fixtures."""
+
+PUPPET_MODULE_URL_1 = urljoin(
+    urljoin(PULP_FIXTURES_BASE_URL, 'puppet/'),
+    '{}-{}.tar.gz'.format(PUPPET_MODULE_1['author'], PUPPET_MODULE_1['name'])
+)
+"""The URL to a Puppet module module available via Pulp Fixtures.
+
+Test cases that require a single module should use this URL, and test cases
+that require a feed should use :data:`PUPPET_MODULE_URL_2`. Doing so shifts
+load away from the Puppet Forge.
+
+Why do both URLs exist? Because simulating the Puppet Forge's behaviour is
+unreasonably hard.
+
+Pulp Fixtures is designed to create data that can be hosted by a simple HTTP
+server, such as ``python3 -m http.server``. A dynamic API, such as the `Puppet
+Forge API`_, cannot be simulated. We could create a static tree of files, where
+that tree of files is the same as what the Puppet Forge would provide in
+response to a certain HTTP GET request. However:
+
+* The `Puppet Forge API`_ will inevitably change over time as bugs are fixed
+  and features are added. This will make a static facsimile of the Puppet Forge
+  API outdated. This is more than a mere inconvenience: outdated information is
+  also confusing!
+* Without an in-depth understanding of each and every file the Puppet Forge
+  yields, it is probable that static fixtures will be wrong from the get-go.
+
+.. _Puppet Forge API: https://forgeapi.puppetlabs.com/
+"""
+
+PUPPET_FEED_2 = 'https://forge.puppet.com'
+"""The URL to a repository of Puppet modules."""
+
+PUPPET_MODULE_2 = {'author': 'puppetlabs', 'name': 'motd', 'version': '1.9.0'}
+"""Information about a Puppet module available at :data:`PUPPET_FEED_2`."""
+
+PUPPET_MODULE_URL_2 = ('{}/v3/files/{}-{}-{}.tar.gz'.format(
+    PUPPET_FEED_2,
+    PUPPET_MODULE_2['author'],
+    PUPPET_MODULE_2['name'],
+    PUPPET_MODULE_2['version'],
+))
+"""The URL to a Puppet module available at :data:`PUPPET_FEED_2`."""
+
+PUPPET_QUERY_2 = quote_plus('-'.join(
+    PUPPET_MODULE_2[key] for key in ('author', 'name', 'version')
+))
+"""A query that can be used to search for Puppet modules.
+
+Built from :data:`PUPPET_MODULE_2`.
+
+Though the `Puppet Forge API`_ supports a variety of search types, Pulp
+only supports the ability to search for modules. As a result, it is
+impossible to create a Puppet repository and sync only an exact module or
+set of modules. This query intentionally returns a small number of Puppet
+modules. A query which selected a large number of modules would produce
+tests that took a long time and abused the free Puppet Forge service.
+
+Beware that the Pulp API takes given Puppet queries and uses them to construct
+URL queries verbatim. Thus, if the user gives a query of "foo bar", the
+following URL is constructed:
+
+    https://forge.puppet.com/modules.json/q=foo bar
+
+In an attempt to avoid this error, this query is encoded before being submitted
+to Pulp.
+
+.. _Puppet Forge API: https://forgeapi.puppetlabs.com/
+"""
+
+PYTHON_PYPI_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python-pypi/')
+"""The URL to the PyPI Python repository."""
+
+PYTHON_EGG_URL = urljoin(
+    PYTHON_PYPI_FEED_URL,
+    'packages/shelf-reader-0.1.tar.gz'
+)
+"""The URL to a Python egg at :data:`PYTHON_PYPI_FEED_URL`."""
+
+PYTHON_WHEEL_URL = urljoin(
+    PYTHON_PYPI_FEED_URL,
+    'packages/shelf_reader-0.1-py2-none-any.whl'
+)
+"""The URL to a Python egg at :data:`PYTHON_PYPI_FEED_URL`."""
+
+RPM_DATA = MappingProxyType({
+    'name': 'bear',
+    'epoch': '0',
+    'version': '4.1',
+    'release': '1',
+    'arch': 'noarch',
+    'metadata': {
+        'release': '1',
+        'license': 'GPLv2',
+        'description': 'A dummy package of bear',
+        'files': {'dir': [], 'file': ['/tmp/bear.txt']},
+        'group': 'Internet/Applications',
+        'size': {'installed': 42, 'package': 1846},
+        'sourcerpm': 'bear-4.1-1.src.rpm',
+        'summary': 'A dummy package of bear',
+        'vendor': None,
+    },
+})
+"""Metadata for an RPM with an associated erratum.
+
+The metadata tags that may be present in an RPM may be printed with:
+
+.. code-block:: sh
+
+    rpm --querytags
+
+Metadata for an RPM can be printed with a command like the following:
+
+.. code-block:: sh
+
+    for tag in name epoch version release arch vendor; do
+        echo "$(rpm -qp bear-4.1-1.noarch.rpm --qf "%{$tag}")"
+    done
+
+There are three ways to measure the size of an RPM:
+
+installed size
+    The size of all the regular files in the payload.
+archive size
+    The uncompressed size of the payload, including necessary CPIO headers.
+package size
+    The actual size of an RPM file, as returned by ``stat --format='%s' …``.
+
+For more information, see the Fedora documentation on `RPM headers
+<https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-package-structure.html#id623000>`_.
+"""
+
+RPM = '{}-{}{}-{}.{}.rpm'.format(
+    RPM_DATA['name'],
+    RPM_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM_DATA['version'],
+    RPM_DATA['release'],
+    RPM_DATA['arch'],
+)
+"""The name of an RPM file.
+
+See :data:`pulp_2_tests.constants.RPM_SIGNED_URL`.
+"""
+
+RPM2_DATA = MappingProxyType({
+    'name': 'camel',
+    'epoch': '0',
+    'version': '0.1',
+    'release': '1',
+    'arch': 'noarch',
+    'metadata': {
+        'release': '1',
+        'license': 'GPLv2',
+        'description': 'A dummy package of camel',
+        'files': {'dir': [], 'file': ['/tmp/camel.txt']},
+        'group': 'Internet/Applications',
+        'size': '42',
+        'sourcerpm': 'camel-0.1-1.src.rpm',
+        'summary': 'A dummy package of camel',
+        'vendor': None,
+    },
+})
+
+RPM2 = '{}-{}{}-{}.{}.rpm'.format(
+    RPM2_DATA['name'],
+    RPM2_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM2_DATA['version'],
+    RPM2_DATA['release'],
+    RPM2_DATA['arch'],
+)
+"""The name of an RPM. See :data:`pulp_2_tests.constants.RPM2_UNSIGNED_URL`."""
+
+RPM_WITH_VENDOR_DATA = MappingProxyType({
+    'name': 'rpm-with-vendor',
+    'epoch': '0',
+    'version': '1',
+    'release': '1.fc25',
+    'arch': 'noarch',
+    'metadata': {
+        'release': '1',
+        'license': 'Public Domain',
+        'description': 'This RPM has a vendor',
+        'files': {'dir': [], 'file': []},
+        'group': None,
+        'size': None,
+        'sourcerpm': None,
+        'summary': None,
+        'vendor': 'Pulp Fixtures',
+    },
+})
+
+RPM_WITH_VENDOR = '{}-{}{}-{}.{}.rpm'.format(
+    RPM_WITH_VENDOR_DATA['name'],
+    RPM_WITH_VENDOR_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM_WITH_VENDOR_DATA['version'],
+    RPM_WITH_VENDOR_DATA['release'],
+    RPM_WITH_VENDOR_DATA['arch'],
+)
+"""The name of an RPM.
+
+See :data:`pulp_2_tests.constants.RPM_WITH_VENDOR_URL`.
+"""
+
+RPM_ALT_LAYOUT_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
+"""The URL to a signed RPM repository. See :data:`RPM_SIGNED_URL`."""
+
+RPM_INCOMPLETE_FILELISTS_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-incomplete-filelists/',
+)
+"""The URL to a repository with an incomplete ``filelists.xml`` file."""
+
+RPM_INCOMPLETE_OTHER_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-incomplete-other/',
+)
+"""The URL to a repository with an incomplete ``other.xml`` file."""
+
+RPM_ERRATUM_ID = 'RHEA-2012:0058'
+"""The ID of an erratum.
+
+The package contained on this erratum is defined by
+:data:`pulp_2_tests.constants.RPM_ERRATUM_RPM_NAME` and the erratum is present
+on repository which feed is :data:`pulp_2_tests.constants.RPM_SIGNED_FEED_URL`.
+"""
+
+RPM_ERRATUM_RPM_NAME = 'gorilla'
+"""The name of the RPM named by :data:`pulp_2_tests.constants.RPM_ERRATUM_ID`."""
+
+RPM_ERRATUM_COUNT = 4
+"""The number of errata in :data:`RPM_UNSIGNED_FEED_URL`."""
+
+RPM_INVALID_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-invalid-rpm/')
+"""The URL to an invalid RPM repository."""
+
+RPM_INVALID_URL = urljoin(RPM_INVALID_FEED_URL, 'invalid.rpm')
+"""The URL to an invalid RPM package."""
+
+RPM_LARGE_UPDATEINFO = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-long-updateinfo/')
+"""The URL to RPM with a large updateinfo.xml."""
+
+RPM_MIRRORLIST_LARGE = (
+    'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=x86_64'
+)
+"""A mirrorlist referencing a large RPM repository.
+
+.. NOTE: The mirrors referenced by this mirrorlist are not operated by Pulp QE.
+    They're public resources and should be sparingly used.
+"""
+
+RPM_MIRRORLIST_BAD = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-mirrorlist-bad')
+"""The URL to a mirrorlist file containing only invalid entries."""
+
+RPM_MIRRORLIST_GOOD = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-mirrorlist-good')
+"""The URL to a mirrorlist file containing only valid entries."""
+
+RPM_MIRRORLIST_MIXED = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-mirrorlist-mixed')
+"""The URL to a mirrorlist file containing invalid and valid entries."""
+
+RPM_MISSING_FILELISTS_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-missing-filelists/',
+)
+"""A repository that's missing its ``filelists.xml`` file."""
+
+RPM_MISSING_OTHER_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-missing-other/',
+)
+"""A repository that's missing its ``other.xml`` file."""
+
+RPM_MISSING_PRIMARY_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-missing-primary/',
+)
+"""A repository that's missing its ``primary.xml`` file."""
+
+RPM_NAMESPACES = {
+    'metadata/common': 'http://linux.duke.edu/metadata/common',
+    'metadata/filelists': 'http://linux.duke.edu/metadata/filelists',
+    'metadata/other': 'http://linux.duke.edu/metadata/other',
+    'metadata/repo': 'http://linux.duke.edu/metadata/repo',
+    'metadata/rpm': 'http://linux.duke.edu/metadata/rpm',
+}
+"""Namespaces used by XML-based RPM metadata.
+
+Many of the XML files generated by the ``createrepo`` utility make use of these
+namespaces. Some of the files that use these namespaces are listed below:
+
+metadata/common
+    Used by ``repodata/primary.xml``.
+
+metadata/filelists
+    Used by ``repodata/filelists.xml``.
+
+metadata/other
+    Used by ``repodata/other.xml``.
+
+metadata/repo
+    Used by ``repodata/repomd.xml``.
+
+metadata/rpm
+    Used by ``repodata/repomd.xml``.
+"""
+
+RPM_PKGLISTS_UPDATEINFO_FEED_URL = (
+    'https://repos.fedorapeople.org/pulp/pulp/fixtures/'
+    'rpm-pkglists-updateinfo/'
+)
+"""A repository whose updateinfo file has multiple ``<pkglist>`` sections."""
+
+RPM_SIGNED_FEED_COUNT = 32
+"""The number of packages available at :data:`RPM_SIGNED_FEED_URL`."""
+
+RPM_SIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-signed/')
+"""The URL to a signed RPM repository. See :data:`RPM_SIGNED_URL`."""
+
+RPM_SIGNED_URL = urljoin(RPM_SIGNED_FEED_URL, RPM)
+"""The URL to an RPM file.
+
+Built from :data:`RPM_SIGNED_FEED_URL` and :data:`RPM`.
+"""
+
+RPM_UNSIGNED_FEED_COUNT = 32
+"""The number of packages available at :data:`RPM_UNSIGNED_FEED_URL`."""
+
+RPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
+"""The URL to an unsigned RPM repository. See :data:`RPM_SIGNED_URL`."""
+
+RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM)
+"""The URL to an unsigned RPM file.
+
+Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM`.
+"""
+
+RPM_UPDATED_INFO_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-updated-updateinfo/'
+)
+"""A repository whose updateinfo file has an errata section."""
+
+RPM2_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM2)
+"""The URL to an unsigned RPM file.
+
+Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM2`.
+"""
+
+RPM_WITH_PULP_DISTRIBUTION_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL, 'rpm-with-pulp-distribution/')
+"""The URL to a RPM repository with a PULP_DISTRIBUTION.xml file."""
+
+RPM_WITH_NON_ASCII_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-ascii/rpm-with-non-ascii-1-1.fc25.noarch.rpm'
+)
+"""The URL to an RPM with non-ascii metadata in its header."""
+
+RPM_WITH_NON_UTF_8_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-utf-8/rpm-with-non-utf-8-1-1.fc25.noarch.rpm'
+)
+"""The URL to an RPM with non-UTF-8 metadata in its header."""
+
+RPM_WITH_VENDOR_FEED_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-vendor/'
+)
+"""A repository whose primary.xml file has an vendor section."""
+
+RPM_WITH_VENDOR_URL = urljoin(
+    RPM_WITH_VENDOR_FEED_URL,
+    'rpm-with-vendor-1-1.fc25.noarch.rpm'
+)
+"""The URL of an RPM with a specified vendor in its header."""
+
+SRPM = 'test-srpm02-1.0-1.src.rpm'
+"""An SRPM file at :data:`pulp_2_tests.constants.SRPM_SIGNED_FEED_URL`."""
+
+SRPM_SIGNED_FEED_COUNT = 3
+"""The number of packages available at :data:`SRPM_SIGNED_FEED_URL`."""
+
+SRPM_SIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-signed/')
+"""The URL to a signed SRPM repository."""
+
+SRPM_SIGNED_URL = urljoin(SRPM_SIGNED_FEED_URL, SRPM)
+"""The URL to an SRPM file.
+
+Built from :data:`SRPM_SIGNED_FEED_URL` and :data:`SRPM`.
+"""
+
+SRPM_UNSIGNED_FEED_COUNT = 3
+"""The number of packages available at :data:`SRPM_UNSIGNED_FEED_COUNT`."""
+
+SRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-unsigned/')
+"""The URL to an unsigned SRPM repository."""
+
+SRPM_UNSIGNED_URL = urljoin(SRPM_UNSIGNED_FEED_URL, SRPM)
+"""The URL to an unsigned SRPM file.
+
+Built from :data:`SRPM_UNSIGNED_FEED_URL` and :data:`SRPM`.
+"""

--- a/pulp_2_tests/tests/docker/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_copy.py
@@ -4,10 +4,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import sync_repo
 
+from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import get_upstream_name, skip_if
 from pulp_2_tests.tests.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_2_tests/tests/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_duplicate_uploads.py
@@ -15,10 +15,10 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import DOCKER_IMAGE_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, DuplicateUploadsMixin
 
+from pulp_2_tests.constants import DOCKER_IMAGE_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/docker/api_v2/test_sync.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_sync.py
@@ -5,10 +5,10 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from requests.exceptions import HTTPError
 
+from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import (
     get_upstream_name,

--- a/pulp_2_tests/tests/docker/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_sync_publish.py
@@ -5,10 +5,10 @@ import unittest
 from jsonschema import validate
 from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
+from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import (
     SyncPublishMixin,
     gen_distributor,

--- a/pulp_2_tests/tests/docker/api_v2/test_tags.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_tags.py
@@ -7,11 +7,11 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, utils
-from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp2.constants import CONTENT_UPLOAD_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, search_units, sync_repo
 
+from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import get_upstream_name, set_up_module
 

--- a/pulp_2_tests/tests/docker/api_v2/test_upload.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_upload.py
@@ -5,9 +5,9 @@ import json
 import unittest
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.utils import pulp_admin_login, upload_import_unit
 
+from pulp_2_tests.constants import DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import SyncPublishMixin
 from pulp_2_tests.tests.docker.utils import (
     get_upstream_name,

--- a/pulp_2_tests/tests/docker/utils.py
+++ b/pulp_2_tests/tests/docker/utils.py
@@ -7,11 +7,12 @@ from unittest import SkipTest
 
 from packaging.version import Version
 from pulp_smash import cli, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2 import utils as pulp2_utils
+
+from pulp_2_tests.constants import (
     DOCKER_UPSTREAM_NAME,
     DOCKER_UPSTREAM_NAME_NOLIST,
 )
-from pulp_smash.pulp2 import utils as pulp2_utils
 
 
 def set_up_module():
@@ -25,9 +26,9 @@ def set_up_module():
 def get_upstream_name(cfg):
     """Return a Docker upstream name.
 
-    Return ``pulp_smash.constants.DOCKER_UPSTREAM_NAME_NOLIST`` if Pulp is
+    Return ``pulp_2_tests.constants.DOCKER_UPSTREAM_NAME_NOLIST`` if Pulp is
     older than version 2.14. Otherwise, return
-    ``pulp_smash.constants.DOCKER_UPSTREAM_NAME``. See the documentation
+    ``pulp_2_tests.constants.DOCKER_UPSTREAM_NAME``. See the documentation
     for those constants for more information.
     """
     if cfg.pulp_version < Version('2.14'):

--- a/pulp_2_tests/tests/ostree/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/ostree/api_v2/test_copy.py
@@ -5,10 +5,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config
-from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import search_units, sync_repo
 
+from pulp_2_tests.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_2_tests.tests.ostree.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/ostree/api_v2/test_crud.py
+++ b/pulp_2_tests/tests/ostree/api_v2/test_crud.py
@@ -12,11 +12,11 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, BaseAPICrudTestCase
 from requests.exceptions import HTTPError
 
+from pulp_2_tests.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_2_tests.tests.ostree.utils import gen_repo
 from pulp_2_tests.tests.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/ostree/api_v2/test_publish.py
+++ b/pulp_2_tests/tests/ostree/api_v2/test_publish.py
@@ -3,10 +3,10 @@
 import unittest
 
 from pulp_smash import api, config
-from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
+from pulp_2_tests.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_2_tests.tests.ostree.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/ostree/api_v2/test_sync.py
+++ b/pulp_2_tests/tests/ostree/api_v2/test_sync.py
@@ -10,10 +10,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, selectors, utils
-from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, sync_repo
 
+from pulp_2_tests.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_2_tests.tests.ostree.utils import gen_repo
 from pulp_2_tests.tests.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -15,10 +15,10 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import PUPPET_MODULE_URL_1
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, DuplicateUploadsMixin
 
+from pulp_2_tests.constants import PUPPET_MODULE_URL_1
 from pulp_2_tests.tests.puppet.api_v2.utils import gen_repo
 from pulp_2_tests.tests.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/puppet/api_v2/test_install_distributor.py
+++ b/pulp_2_tests/tests/puppet/api_v2/test_install_distributor.py
@@ -9,7 +9,6 @@ For more information check `puppet_install_distributor`_
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, utils, selectors
-from pulp_smash.constants import PUPPET_MODULE_1, PUPPET_MODULE_URL_1
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     BaseAPITestCase,
@@ -17,6 +16,7 @@ from pulp_smash.pulp2.utils import (
     upload_import_unit,
 )
 
+from pulp_2_tests.constants import PUPPET_MODULE_1, PUPPET_MODULE_URL_1
 from pulp_2_tests.tests.puppet.utils import os_is_f27
 from pulp_2_tests.tests.puppet.api_v2.utils import (
     gen_install_distributor,

--- a/pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py
@@ -9,14 +9,6 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import (
-    PUPPET_FEED_2,
-    PUPPET_MODULE_1,
-    PUPPET_MODULE_2,
-    PUPPET_MODULE_URL_1,
-    PUPPET_MODULE_URL_2,
-    PUPPET_QUERY_2,
-)
 from pulp_smash.pulp2.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,
@@ -31,6 +23,14 @@ from pulp_smash.pulp2.utils import (
 )
 from requests.exceptions import HTTPError
 
+from pulp_2_tests.constants import (
+    PUPPET_FEED_2,
+    PUPPET_MODULE_1,
+    PUPPET_MODULE_2,
+    PUPPET_MODULE_URL_1,
+    PUPPET_MODULE_URL_2,
+    PUPPET_QUERY_2,
+)
 from pulp_2_tests.tests.puppet.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
@@ -97,7 +97,7 @@ class SyncValidFeedTestCase(BaseAPITestCase):
         Assert that:
 
         * None of the sync tasks has an error message.
-        * Searching for module ``pulp_smash.constants.PUPPET_MODULE_2``
+        * Searching for module ``pulp_2_tests.constants.PUPPET_MODULE_2``
           yields one result.
         * The synced-in module can be downloaded.
         """
@@ -145,7 +145,7 @@ class SyncValidFeedTestCase(BaseAPITestCase):
         Assert that:
 
         * None of the sync tasks has an error message.
-        * Searching for module ``pulp_smash.constants.PUPPET_MODULE_2``
+        * Searching for module ``pulp_2_tests.constants.PUPPET_MODULE_2``
           yields no results.
         """
         # Create and sync a repository.

--- a/pulp_2_tests/tests/puppet/cli/test_sync.py
+++ b/pulp_2_tests/tests/puppet/cli/test_sync.py
@@ -3,9 +3,9 @@
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import PUPPET_FEED_2, PUPPET_QUERY_2
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import PUPPET_FEED_2, PUPPET_QUERY_2
 from pulp_2_tests.tests.puppet.utils import set_up_module
 
 

--- a/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
@@ -18,10 +18,10 @@ from urllib.parse import urlsplit
 
 from packaging.version import Version
 from pulp_smash import api, utils
-from pulp_smash.constants import PYTHON_EGG_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, DuplicateUploadsMixin
 
+from pulp_2_tests.constants import PYTHON_EGG_URL
 from pulp_2_tests.tests.python.api_v2.utils import gen_repo
 from pulp_2_tests.tests.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
@@ -6,7 +6,7 @@ from os.path import basename
 from urllib.parse import urljoin, urlparse
 
 from packaging.version import Version
-from pulp_smash import api, config, constants, selectors, utils
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH, ORPHANS_PATH
 from pulp_smash.pulp2.utils import (
     publish_repo,
@@ -15,6 +15,11 @@ from pulp_smash.pulp2.utils import (
     upload_import_unit,
 )
 
+from pulp_2_tests.constants import (
+    PYTHON_EGG_URL,
+    PYTHON_PYPI_FEED_URL,
+    PYTHON_WHEEL_URL,
+)
 from pulp_2_tests.tests.python.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_2_tests.tests.python.utils import skip_if
@@ -134,7 +139,7 @@ class SyncTestCase(BaseTestCase):
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
         body['importer_config'] = {
-            'feed': constants.PYTHON_PYPI_FEED_URL,
+            'feed': PYTHON_PYPI_FEED_URL,
             'package_names': 'shelf-reader',
         }
         body['distributors'] = [gen_distributor()]
@@ -179,8 +184,8 @@ class UploadTestCase(BaseTestCase):
                 'unit_type_id': 'python_package',
             }, repo)
 
-        _upload_import_unit(constants.PYTHON_EGG_URL)
-        _upload_import_unit(constants.PYTHON_WHEEL_URL)
+        _upload_import_unit(PYTHON_EGG_URL)
+        _upload_import_unit(PYTHON_WHEEL_URL)
         with self.subTest(comment='verify content units are present'):
             self.verify_package_types(self.cfg, repo)
         repo = get_details(self.cfg, repo)

--- a/pulp_2_tests/tests/rpm/api_v2/test_broker.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_broker.py
@@ -29,10 +29,10 @@ import unittest
 
 from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_smash.pulp2.constants import PULP_SERVICES, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import get_broker, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_character_encoding.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_character_encoding.py
@@ -8,10 +8,10 @@ sequences are encountered.
 import unittest
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_UTF_8_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import upload_import_unit
 
+from pulp_2_tests.constants import RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_UTF_8_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
@@ -22,7 +22,7 @@ class UploadNonAsciiTestCase(unittest.TestCase):
     Specifically, do the following:
 
     1. Create an RPM repository.
-    2. Upload and import ``pulp_smash.constants.RPM_WITH_NON_ASCII_URL``
+    2. Upload and import ``pulp_2_tests.constants.RPM_WITH_NON_ASCII_URL``
        into the repository.
     """
 
@@ -42,7 +42,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     Specifically, do the following:
 
     1. Create an RPM repository.
-    2. Upload and import ``pulp_smash.constants.RPM_WITH_NON_UTF_8_URL``
+    2. Upload and import ``pulp_2_tests.constants.RPM_WITH_NON_UTF_8_URL``
        into the repository.
 
     This test case targets `Pulp #1903 <https://pulp.plan.io/issues/1903>`_.

--- a/pulp_2_tests/tests/rpm/api_v2/test_comps_xml.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_comps_xml.py
@@ -4,7 +4,7 @@
 Each RPM repository has a ``repodata`` directory, in which various XML files
 containing metadata are present. This module houses test cases which verify the
 ``comps.xml`` file. For a sample ``comps.xml`` file, search through
-``pulp_smash.constants.RPM_SIGNED_FEED_URL``.
+``pulp_2_tests.constants.RPM_SIGNED_FEED_URL``.
 """
 import unittest
 from urllib.parse import urljoin
@@ -12,7 +12,6 @@ from xml.etree import ElementTree
 
 from packaging.version import Version
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
@@ -20,6 +19,7 @@ from pulp_smash.pulp2.constants import (
 )
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_content_applicability.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_content_applicability.py
@@ -10,11 +10,6 @@ from urllib.parse import urljoin
 
 from jsonschema import validate
 from pulp_smash import api, config, utils
-from pulp_smash.constants import (
-    RPM_UNSIGNED_FEED_URL,
-    RPM_DATA,
-    RPM2_DATA,
-)
 from pulp_smash.pulp2.constants import (
     CONSUMERS_ACTIONS_CONTENT_REGENERATE_APPLICABILITY_PATH,
     CONSUMERS_CONTENT_APPLICABILITY_PATH,
@@ -23,6 +18,11 @@ from pulp_smash.pulp2.constants import (
 )
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
+from pulp_2_tests.constants import (
+    RPM_UNSIGNED_FEED_URL,
+    RPM_DATA,
+    RPM2_DATA,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_content_sources.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_content_sources.py
@@ -10,9 +10,9 @@ from io import StringIO
 from urllib.parse import urlsplit, urlunsplit
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import PULP_FIXTURES_BASE_URL
 from pulp_smash.pulp2.constants import CONTENT_SOURCES_PATH
 
+from pulp_2_tests.constants import PULP_FIXTURES_BASE_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _HEADERS = {'X-RHUI-ID', 'X-CSRF-TOKEN'}

--- a/pulp_2_tests/tests/rpm/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_copy.py
@@ -6,11 +6,6 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
-    RPM_SIGNED_URL,
-    RPM_UNSIGNED_FEED_URL,
-    RPM_UPDATED_INFO_FEED_URL,
-)
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     publish_repo,
@@ -19,6 +14,11 @@ from pulp_smash.pulp2.utils import (
     upload_import_unit,
 )
 
+from pulp_2_tests.constants import (
+    RPM_SIGNED_URL,
+    RPM_UNSIGNED_FEED_URL,
+    RPM_UPDATED_INFO_FEED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_crud.py
@@ -12,10 +12,6 @@ from urllib.parse import urljoin
 import requests
 from packaging import version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
-    RPM_UNSIGNED_FEED_URL,
-    RPM_WITH_PULP_DISTRIBUTION_FEED_URL,
-)
 from pulp_smash.pulp2.constants import REPOSITORY_GROUP_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     BaseAPITestCase,
@@ -24,6 +20,10 @@ from pulp_smash.pulp2.utils import (
     sync_repo,
 )
 
+from pulp_2_tests.constants import (
+    RPM_UNSIGNED_FEED_URL,
+    RPM_WITH_PULP_DISTRIBUTION_FEED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
@@ -11,7 +11,6 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     BaseAPITestCase,
@@ -20,6 +19,7 @@ from pulp_smash.pulp2.utils import (
     sync_repo,
 )
 
+from pulp_2_tests.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
@@ -297,7 +297,7 @@ class FixFileCorruptionTestCase(BaseAPITestCase):
 
     @classmethod
     def get_rpm_abs_path(cls):
-        """Return the absolute path to ``pulp_smash.constants.RPM``."""
+        """Return the absolute path to ``pulp_2_tests.constants.RPM``."""
         return cli.Client(cls.cfg).run(
             'find /var/lib/pulp/content/units/rpm/ -type f -name'
             .split() + [RPM]

--- a/pulp_2_tests/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -6,10 +6,10 @@ import unittest
 from urllib.parse import urlsplit
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import FILE_URL, RPM_UNSIGNED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import upload_import_unit
 
+from pulp_2_tests.constants import FILE_URL, RPM_UNSIGNED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_errata.py
@@ -3,10 +3,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors
-from pulp_smash.constants import RPM_LARGE_UPDATEINFO, RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_LARGE_UPDATEINFO, RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
@@ -123,7 +123,7 @@ class LargePackageListTestCase(unittest.TestCase):
         Do the following:
 
         1. Create two repositories, each with a feed URL of
-           ``pulp_smash.constants.RPM_LARGE_UPDATEINFO``.
+           ``pulp_2_tests.constants.RPM_LARGE_UPDATEINFO``.
         2. Sync both repositories. Assert that each sync finishes without
            errors.
         """

--- a/pulp_2_tests/tests/rpm/api_v2/test_export.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_export.py
@@ -13,7 +13,6 @@ from xml.dom import minidom
 from dateutil.parser import parse
 from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_smash.pulp2.constants import (
     REPOSITORY_EXPORT_DISTRIBUTOR,
     REPOSITORY_GROUP_EXPORT_DISTRIBUTOR,
@@ -22,6 +21,7 @@ from pulp_smash.pulp2.constants import (
 )
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM, RPM_SIGNED_FEED_URL, RPM_SIGNED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     DisableSELinuxMixin,
     gen_distributor,
@@ -462,7 +462,7 @@ class ExportDistributorTestCase(ExportDirMixin, BaseAPITestCase):
     def test_publish_to_dir(self):
         """Publish the repository to a directory on the Pulp server.
 
-        gerify that ``pulp_smash.constants.RPM`` is present and has a
+        gerify that ``pulp_2_tests.constants.RPM`` is present and has a
         correct checksum.
 
         This test is skipped if selinux is installed and enabled on the target

--- a/pulp_2_tests/tests/rpm/api_v2/test_force_full.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_force_full.py
@@ -11,10 +11,10 @@ This module tests Pulp's handling of "full" publishes.
 """
 from packaging.version import Version
 from pulp_smash import api, selectors
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
@@ -9,14 +9,14 @@ from urllib.parse import urljoin, urlparse
 import requests
 from packaging.version import Version
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import BaseAPITestCase, search_units, sync_repo
+
+from pulp_2_tests.constants import (
     FILE_FEED_URL,
     FILE_MIXED_FEED_URL,
     FILE2_FEED_URL,
 )
-from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import BaseAPITestCase, search_units, sync_repo
-
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_sync_publish.py
@@ -6,14 +6,14 @@ import unittest
 from urllib.parse import urljoin, urlparse, urlsplit
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import publish_repo, sync_repo, upload_import_unit
+
+from pulp_2_tests.constants import (
     FILE_FEED_COUNT,
     FILE_FEED_URL,
     FILE_URL,
 )
-from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import publish_repo, sync_repo, upload_import_unit
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     TemporaryUserMixin,
     get_dists_by_type_id,
@@ -132,7 +132,7 @@ class UploadIsoTestCase(unittest.TestCase):
         Specifically, do the following:
 
         1. Create an ISO repository.
-        2. Upload ``pulp_smash.constants.FILE_URL`` to the repository.
+        2. Upload ``pulp_2_tests.constants.FILE_URL`` to the repository.
         3. Publish the repository.
         4. Download the published ISO, and assert it's equal to the uploaded
            ISO.

--- a/pulp_2_tests/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_mirrorlist.py
@@ -17,17 +17,17 @@ import unittest
 
 from packaging.version import Version
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.exceptions import TaskReportError
+from pulp_smash.pulp2.utils import publish_repo, sync_repo
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+
+from pulp_2_tests.constants import (
     RPM,
     RPM_MIRRORLIST_BAD,
     RPM_MIRRORLIST_GOOD,
     RPM_MIRRORLIST_MIXED,
     RPM_UNSIGNED_URL,
 )
-from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp2.utils import publish_repo, sync_repo
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_no_op_publish.py
@@ -30,10 +30,10 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, exceptions, utils
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_2277, check_issue_3104
 from pulp_2_tests.tests.rpm.utils import set_up_module

--- a/pulp_2_tests/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_orphan_remove.py
@@ -16,10 +16,10 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_2_tests.tests.rpm.utils import skip_if

--- a/pulp_2_tests/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_package_paths.py
@@ -32,14 +32,14 @@ situations.
 import unittest
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import publish_repo, sync_repo
+
+from pulp_2_tests.constants import (
     RPM,
     RPM_ALT_LAYOUT_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import publish_repo, sync_repo
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_remove_unit.py
@@ -9,10 +9,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import RPM_SIGNED_FEED_URL, RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, search_units, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL, RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import (
     check_issue_2277,

--- a/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
@@ -8,10 +8,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import RPM_NAMESPACES, RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_NAMESPACES, RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_repository_layout.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repository_layout.py
@@ -19,10 +19,10 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api
-from pulp_smash.constants import RPM_NAMESPACES, RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_NAMESPACES, RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_repoview.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repoview.py
@@ -12,10 +12,11 @@ import unittest
 from urllib.parse import urljoin
 
 from packaging.version import Version
-from pulp_smash import api, config, constants, selectors, utils
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, upload_import_unit
 
+from pulp_2_tests.constants import RPM_UNSIGNED_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 
@@ -48,7 +49,7 @@ class RepoviewTestCase(unittest.TestCase):
         body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body).json()
         self.addCleanup(client.delete, repo['_href'])
-        rpm = utils.http_get(constants.RPM_UNSIGNED_URL)
+        rpm = utils.http_get(RPM_UNSIGNED_URL)
         upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)
 
         # Get info about the repo distributor

--- a/pulp_2_tests/tests/rpm/api_v2/test_republish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_republish.py
@@ -7,11 +7,6 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
-    RPM2_UNSIGNED_URL,
-    RPM_UNSIGNED_FEED_URL,
-    RPM_UNSIGNED_URL,
-)
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     publish_repo,
@@ -20,6 +15,11 @@ from pulp_smash.pulp2.utils import (
     upload_import_unit,
 )
 
+from pulp_2_tests.constants import (
+    RPM2_UNSIGNED_URL,
+    RPM_UNSIGNED_FEED_URL,
+    RPM_UNSIGNED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
@@ -13,10 +13,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api
-from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_3104
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_2_tests/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rsync_distributor.py
@@ -58,15 +58,15 @@ from urllib.parse import urljoin, urlparse
 
 from requests.exceptions import HTTPError
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import publish_repo, sync_repo, upload_import_unit
+
+from pulp_2_tests.constants import (
     RPM2_UNSIGNED_URL,
     RPM_SIGNED_FEED_COUNT,
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import publish_repo, sync_repo, upload_import_unit
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     DisableSELinuxMixin,
     TemporaryUserMixin,
@@ -210,7 +210,7 @@ class _RsyncDistUtilsMixin():  # pylint:disable=too-few-public-methods
             distributor.
         :param num_units: The number of units that should be on the target
             system's filesystem. Defaults to
-            ``pulp_smash.constants.RPM_SIGNED_FEED_COUNT`.
+            ``pulp_2_tests.constants.RPM_SIGNED_FEED_COUNT`.
         :returns: Nothing.
         """
         if num_units is None:

--- a/pulp_2_tests/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_schedule_publish.py
@@ -8,10 +8,10 @@ import time
 from urllib.parse import urljoin
 
 from pulp_smash import api, utils
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_schedule_sync.py
@@ -9,10 +9,10 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, utils
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_search.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_search.py
@@ -18,15 +18,15 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import CONTENT_UNITS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import BaseAPITestCase, sync_repo
+
+from pulp_2_tests.constants import (
     RPM,
     RPM_SIGNED_FEED_URL,
     SRPM,
     SRPM_SIGNED_FEED_URL,
 )
-from pulp_smash.pulp2.constants import CONTENT_UNITS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import BaseAPITestCase, sync_repo
-
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_2620
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
@@ -85,7 +85,7 @@ class SearchForRpmTestCase(BaseSearchTestCase):
         """Search for all "rpm" units.
 
         Perform the following searches. Assert a unit with filename
-        ``pulp_smash.constants.RPM`` is in the search results.
+        ``pulp_2_tests.constants.RPM`` is in the search results.
 
         ==== ====================
         GET  n/a
@@ -107,7 +107,7 @@ class SearchForRpmTestCase(BaseSearchTestCase):
         """Search for all "rpm" units, and include repos in the results.
 
         Perform the following searches. Assert a unit with filename
-        ``pulp_smash.constants.RPM`` is in the search results, and assert
+        ``pulp_2_tests.constants.RPM`` is in the search results, and assert
         it belongs to the repository created in
         :meth:`BaseSearchTestCase.setUpClass`.
 
@@ -141,7 +141,7 @@ class SearchForSrpmTestCase(BaseSearchTestCase):
         """Search for all "srpm" units.
 
         Perform the following searches. Assert a unit with filename
-        ``pulp_smash.constants.SRPM`` is in the search results.
+        ``pulp_2_tests.constants.SRPM`` is in the search results.
 
         ==== ====================
         GET  n/a
@@ -163,7 +163,7 @@ class SearchForSrpmTestCase(BaseSearchTestCase):
         """Search for all "srpm" units, and include repos in the results.
 
         Perform the following searches. Assert a unit with filename
-        ``pulp_smash.constants.SRPM`` is in the search results, and assert
+        ``pulp_2_tests.constants.SRPM`` is in the search results, and assert
         it belongs to the repository created in
         :meth:`BaseSearchTestCase.setUpClass`.
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py
@@ -10,7 +10,6 @@ from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 from pulp_smash import api, cli, config, selectors
-from pulp_smash.constants import RPM_MIRRORLIST_LARGE, RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import (
     PULP_SERVICES,
     REPOSITORY_PATH,
@@ -18,6 +17,7 @@ from pulp_smash.pulp2.constants import (
 )
 from pulp_smash.pulp2.utils import get_broker, reset_pulp, sync_repo
 
+from pulp_2_tests.constants import RPM_MIRRORLIST_LARGE, RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
@@ -37,7 +37,7 @@ class MissingWorkersTestCase(unittest.TestCase):
        For details, see `Pulp #2835`_.) This should cause the first sync to
        abort.
     4. Update the repository. Let its feed reference a small repository. (For
-       example, ``pulp_smash.constants.RPM_UNSIGNED_FEED_URL``.)
+       example, ``pulp_2_tests.constants.RPM_UNSIGNED_FEED_URL``.)
     5. Start a sync. Verify that it completes. If `Pulp #2835`_ still affects
        Pulp, then the worker will be broken, and the sync will never start.
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -26,18 +26,18 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import PULP_FIXTURES_KEY_ID
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import upload_import_unit
+
+from pulp_2_tests.constants import (
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_URL,
-    PULP_FIXTURES_KEY_ID,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import upload_import_unit
-
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_3875, set_up_module
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -22,12 +22,15 @@ import inspect
 import unittest
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import (
+from pulp_smash.constants import PULP_FIXTURES_KEY_ID
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import sync_repo
+
+from pulp_2_tests.constants import (
     DRPM_SIGNED_FEED_COUNT,
     DRPM_SIGNED_FEED_URL,
     DRPM_UNSIGNED_FEED_COUNT,
     DRPM_UNSIGNED_FEED_URL,
-    PULP_FIXTURES_KEY_ID,
     RPM_SIGNED_FEED_COUNT,
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_FEED_COUNT,
@@ -37,9 +40,6 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_COUNT,
     SRPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import sync_repo
-
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -47,20 +47,20 @@ For more information, see `Pulp #1991`_ and `Pulp Smash #347`_.
 import unittest
 from itertools import chain
 
-from requests.exceptions import HTTPError
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import PULP_FIXTURES_KEY_ID
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import BaseAPITestCase, upload_import_unit
+from requests.exceptions import HTTPError
+
+from pulp_2_tests.constants import (
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_URL,
-    PULP_FIXTURES_KEY_ID,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import BaseAPITestCase, upload_import_unit
-
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -20,12 +20,15 @@ import unittest
 from urllib.parse import urlparse
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import PULP_FIXTURES_KEY_ID
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import search_units, sync_repo, upload_import_unit
+
+from pulp_2_tests.constants import (
     DRPM_SIGNED_FEED_URL,
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_FEED_URL,
     DRPM_UNSIGNED_URL,
-    PULP_FIXTURES_KEY_ID,
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_FEED_URL,
@@ -35,9 +38,6 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import search_units, sync_repo, upload_import_unit
-
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_2620
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
@@ -16,7 +16,11 @@ from urllib.parse import urljoin
 
 from packaging.version import Version
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
+from requests.exceptions import HTTPError
+
+from pulp_2_tests.constants import (
     DRPM_UNSIGNED_FEED_URL,
     RPM,
     RPM_ERRATUM_COUNT,
@@ -31,10 +35,6 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_FEED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import BaseAPITestCase, publish_repo, sync_repo
-from requests.exceptions import HTTPError
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_tasks.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_tasks.py
@@ -13,10 +13,10 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH, TASKS_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_unassociate.py
@@ -12,14 +12,6 @@ from urllib.parse import urljoin
 from dateutil.parser import parse
 from packaging.version import Version
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
-    DRPM_UNSIGNED_FEED_URL,
-    RPM,
-    RPM_UNSIGNED_FEED_COUNT,
-    RPM_UNSIGNED_FEED_URL,
-    RPM_UNSIGNED_URL,
-    SRPM_UNSIGNED_FEED_URL,
-)
 from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     BaseAPITestCase,
@@ -29,6 +21,14 @@ from pulp_smash.pulp2.utils import (
     upload_import_unit,
 )
 
+from pulp_2_tests.constants import (
+    DRPM_UNSIGNED_FEED_URL,
+    RPM,
+    RPM_UNSIGNED_FEED_COUNT,
+    RPM_UNSIGNED_FEED_URL,
+    RPM_UNSIGNED_URL,
+    SRPM_UNSIGNED_FEED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_2620
 from pulp_2_tests.tests.rpm.utils import set_up_module

--- a/pulp_2_tests/tests/rpm/api_v2/test_unavailable_checksum.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_unavailable_checksum.py
@@ -3,16 +3,16 @@
 import unittest
 
 from pulp_smash import api, config
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.exceptions import TaskReportError
+from pulp_smash.pulp2.utils import publish_repo, search_units, sync_repo
+
+from pulp_2_tests.constants import (
     DRPM_UNSIGNED_FEED_URL,
     RPM_NAMESPACES,
     RPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp2.utils import publish_repo, search_units, sync_repo
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_2_tests/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_updateinfo.py
@@ -44,18 +44,6 @@ from xml.etree import ElementTree
 
 from packaging.version import Version
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
-    OPENSUSE_FEED_URL,
-    RPM,
-    RPM_DATA,
-    RPM_ERRATUM_ID,
-    RPM_ERRATUM_RPM_NAME,
-    RPM_NAMESPACES,
-    RPM_PKGLISTS_UPDATEINFO_FEED_URL,
-    RPM_SIGNED_FEED_URL,
-    RPM_UNSIGNED_FEED_URL,
-    RPM_UNSIGNED_URL,
-)
 from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     BaseAPITestCase,
@@ -67,6 +55,18 @@ from pulp_smash.pulp2.utils import (
 )
 from requests.exceptions import HTTPError
 
+from pulp_2_tests.constants import (
+    OPENSUSE_FEED_URL,
+    RPM,
+    RPM_DATA,
+    RPM_ERRATUM_ID,
+    RPM_ERRATUM_RPM_NAME,
+    RPM_NAMESPACES,
+    RPM_PKGLISTS_UPDATEINFO_FEED_URL,
+    RPM_SIGNED_FEED_URL,
+    RPM_UNSIGNED_FEED_URL,
+    RPM_UNSIGNED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
@@ -370,9 +370,9 @@ class UpdateRepoTestCase(BaseAPITestCase):
         verify that:
 
         * An ``<update>`` with an ``<id>`` of
-          ``pulp_smash.constants.RPM_ERRATUM_ID`` is present, and
+          ``pulp_2_tests.constants.RPM_ERRATUM_ID`` is present, and
         * one of its child ``<package>`` elements has a "name" attribute equal
-          to ``pulp_smash.constants.RPM_ERRATUM_RPM_NAME``.
+          to ``pulp_2_tests.constants.RPM_ERRATUM_RPM_NAME``.
         """
         sync_repo(self.cfg, self.repo)
         publish_repo(self.cfg, self.repo)
@@ -394,7 +394,7 @@ class UpdateRepoTestCase(BaseAPITestCase):
         """Unassociate a content unit and publish the repository.
 
         Fetch ``updateinfo.xml``. Verify that an ``<update>`` with an ``<id>``
-        of ``pulp_smash.constants.RPM_ERRATUM_ID`` is not present.
+        of ``pulp_2_tests.constants.RPM_ERRATUM_ID`` is not present.
         """
         client = api.Client(self.cfg, api.json_handler)
         client.post(urljoin(self.repo['_href'], 'actions/unassociate/'), {
@@ -420,7 +420,7 @@ class PkglistsTestCase(unittest.TestCase):
         Specifically, do the following:
 
         1. Create, sync and publish an RPM repository whose feed is set to
-           ``pulp_smash.constants.RPM_PKGLISTS_UPDATEINFO_FEED_URL``.
+           ``pulp_2_tests.constants.RPM_PKGLISTS_UPDATEINFO_FEED_URL``.
         2. Fetch and parse the published repository's ``updateinfo.xml`` file.
 
         Verify that the ``updateinfo.xml`` file has three packages whose
@@ -583,7 +583,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
     Do the following:
 
     1. Create, sync and publish a repository. Let its feed URL reference
-       ``pulp_smash.constants.OPENSUSE_FEED_URL``. Also, let it have an "on
+       ``pulp_2_tests.constants.OPENSUSE_FEED_URL``. Also, let it have an "on
        demand" download policy, so that time isn't spent syncing a potentially
        large amount of data.
     2. Download the published errata, and make it available to the remaining

--- a/pulp_2_tests/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_upload_publish.py
@@ -13,7 +13,16 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, exceptions, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.utils import (
+    BaseAPITestCase,
+    publish_repo,
+    search_units,
+    sync_repo,
+    upload_import_unit,
+)
+
+from pulp_2_tests.constants import (
     DRPM,
     DRPM_UNSIGNED_URL,
     RPM,
@@ -26,15 +35,6 @@ from pulp_smash.constants import (
     SRPM,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
-from pulp_smash.pulp2.utils import (
-    BaseAPITestCase,
-    publish_repo,
-    search_units,
-    sync_repo,
-    upload_import_unit,
-)
-
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
@@ -363,7 +363,7 @@ class UploadRpmTestCase(BaseAPITestCase):
                 )
 
     def verify_repo_download(self, repo):
-        """Download ``pulp_smash.constants.RPM` from the given ``repo``.
+        """Download ``pulp_2_tests.constants.RPM` from the given ``repo``.
 
         Verify that it is exactly equal to the one uploaded earlier.
         """

--- a/pulp_2_tests/tests/rpm/api_v2/utils.py
+++ b/pulp_2_tests/tests/rpm/api_v2/utils.py
@@ -10,8 +10,9 @@ from xml.etree import ElementTree
 
 from packaging.version import Version
 from pulp_smash import api, cli, exceptions, selectors, utils
-from pulp_smash.constants import RPM_NAMESPACES
 from pulp_smash.pulp2.utils import search_units
+
+from pulp_2_tests.constants import RPM_NAMESPACES
 
 
 def gen_repo(**kwargs):

--- a/pulp_2_tests/tests/rpm/cli/test_character_encoding.py
+++ b/pulp_2_tests/tests/rpm/cli/test_character_encoding.py
@@ -8,9 +8,9 @@ sequences are encountered.
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_UTF_8_URL
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_UTF_8_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module
 
 
@@ -26,7 +26,7 @@ class UploadNonAsciiTestCase(unittest.TestCase):
     Specifically, do the following:
 
     1. Create an RPM repository.
-    2. Upload and import ``pulp_smash.constants.RPM_WITH_NON_ASCII_URL``
+    2. Upload and import ``pulp_2_tests.constants.RPM_WITH_NON_ASCII_URL``
        into the repository.
     """
 
@@ -65,7 +65,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     Specifically, do the following:
 
     1. Create an RPM repository.
-    2. Upload and import ``pulp_smash.constants.RPM_WITH_NON_UTF_8_URL``
+    2. Upload and import ``pulp_2_tests.constants.RPM_WITH_NON_UTF_8_URL``
        into the repository.
 
     This test case targets `Pulp #1903 <https://pulp.plan.io/issues/1903>`_.

--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -5,9 +5,10 @@ import unittest
 from urllib.parse import urljoin
 
 from packaging.version import Version
-from pulp_smash import cli, config, constants, selectors, utils
+from pulp_smash import cli, config, selectors, utils
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.cli.utils import count_langpacks
 from pulp_2_tests.tests.rpm.utils import (
     check_issue_2277,
@@ -37,7 +38,7 @@ def setUpModule():  # pylint:disable=invalid-name
     pulp_admin_login(cfg)
     client.run(
         'pulp-admin rpm repo create --repo-id {} --feed {}'
-        .format(_REPO_ID, constants.RPM_SIGNED_FEED_URL).split()
+        .format(_REPO_ID, RPM_SIGNED_FEED_URL).split()
     )
 
     # If setUpModule() fails, tearDownModule() isn't run. In addition, we can't

--- a/pulp_2_tests/tests/rpm/cli/test_environments.py
+++ b/pulp_2_tests/tests/rpm/cli/test_environments.py
@@ -5,9 +5,9 @@ import unittest
 
 from packaging.version import Version
 from pulp_smash import cli, config, utils
-from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 

--- a/pulp_2_tests/tests/rpm/cli/test_process_recycling.py
+++ b/pulp_2_tests/tests/rpm/cli/test_process_recycling.py
@@ -4,10 +4,10 @@ import time
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.constants import PULP_SERVICES
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module
 
 

--- a/pulp_2_tests/tests/rpm/cli/test_retain_old_count.py
+++ b/pulp_2_tests/tests/rpm/cli/test_retain_old_count.py
@@ -14,9 +14,9 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import cli, config, utils
-from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.utils import check_issue_3104
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_2_tests/tests/rpm/cli/test_sync.py
+++ b/pulp_2_tests/tests/rpm/cli/test_sync.py
@@ -4,9 +4,9 @@ import random
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.pulp2.utils import pulp_admin_login, reset_pulp
 
+from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.utils import check_issue_2620, set_up_module
 
 

--- a/pulp_2_tests/tests/rpm/cli/test_upload.py
+++ b/pulp_2_tests/tests/rpm/cli/test_upload.py
@@ -4,9 +4,9 @@ import os
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import DRPM, DRPM_UNSIGNED_URL
 from pulp_smash.pulp2.utils import pulp_admin_login
 
+from pulp_2_tests.constants import DRPM, DRPM_UNSIGNED_URL
 from pulp_2_tests.tests.rpm.utils import set_up_module
 
 


### PR DESCRIPTION
Rationale: Pulp 3 smash tests are already going to be carrying their own content-specific constants, so it'll be in two places anyway.  It makes sense to put them here instead of in pulp_smash (exception: I left the base fixtures URL behind).