### PR TITLE
Refactor repomd.xml test case, and support modularity

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
@@ -7,6 +7,7 @@ import os
 import unittest
 from urllib.parse import urljoin
 
+from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
@@ -78,6 +79,9 @@ class RepoMDTestCase(unittest.TestCase):
             'primary',
             'updateinfo',
         }
+        # Pulp 2.17 adds support for modularity.
+        if self.cfg.pulp_version >= Version('2.17'):
+            expected_data_types.add('modules')
         self.assertEqual(data_types, expected_data_types)
 
 


### PR DESCRIPTION
The first commit refactors an existing test case, so that it no longer inherits from a legacy base class. The second commit updates the test case to deal with the new modularity support added in Pulp 2.17. This PR fixes a test failure. I'd appreciate a review from someone who's familiar with Pulp's support for modularity. @jortel?