### PR TITLE
Skip test affected by Pulp issue 3904

### DIFF
--- a/pulp_2_tests/tests/docker/api_v2/test_upload.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_upload.py
@@ -33,7 +33,7 @@ class UploadManifestListV2TestCase(SyncPublishMixin, unittest.TestCase):
         if (os_is_f26(cls.cfg) and
                 not selectors.bug_is_fixed(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
-        for issue_id in (2287, 2384, 2993):
+        for issue_id in (2287, 2384, 2993, 3904):
             if not selectors.bug_is_fixed(issue_id, cls.cfg.pulp_version):
                 raise unittest.SkipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)


### PR DESCRIPTION
Issue title: "Can't upload manifest list to Docker repository"

See: https://pulp.plan.io/issues/3904