### PR TITLE
Skip tests affected by Pulp issue 3895

### DIFF
--- a/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_2_tests/tests/python/api_v2/test_duplicate_uploads.py
@@ -14,6 +14,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp #1406: https://pulp.plan.io/issues/1406
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
+import unittest
 from urllib.parse import urlsplit
 
 from packaging.version import Version
@@ -33,6 +34,8 @@ class DuplicateUploadsTestCase(BaseAPITestCase, DuplicateUploadsMixin):
     def setUpClass(cls):
         """Create a Python repo. Upload a Python package into it twice."""
         super().setUpClass()
+        if utils.fips_is_supported(cls.cfg) and utils.fips_is_enabled(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/3895')
         unit = utils.http_get(PYTHON_EGG_URL)
         import_params = {'unit_key': {}, 'unit_type_id': 'python_package'}
         if cls.cfg.pulp_version >= Version('2.11'):

--- a/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/python/api_v2/test_sync_publish.py
@@ -41,6 +41,8 @@ class BaseTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
+        if utils.fips_is_supported(cls.cfg) and utils.fips_is_enabled(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/3895')
         cls.repos = []
         if inspect.getmro(cls)[0] == BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')


### PR DESCRIPTION
Issue title: "Python API Upload and duplicate upload test cases fail in
FIPS environment"

See: https://pulp.plan.io/issues/3895