### PR TITLE
Adjust number of RPM verions on RetainOldCountTestCase.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
@@ -59,7 +59,7 @@ class RetainOldCountTestCase(BaseAPITestCase):
         """
         repo = self.create_sync_repo(0)
         counts = [_['content_unit_counts']['rpm'] for _ in (self.repo, repo)]
-        self.assertEqual(counts[0] - 1, counts[1])
+        self.assertEqual(counts[0] - 3, counts[1])
 
     def test_retain_one(self):
         """Give ``retain_old_count`` a value of one.


### PR DESCRIPTION
There are two versions of 3 different RPMs present on the repository
used to execute the test. Adjust the number of RPMs present in the
`test_retain_zero`.

See: See: PulpQE/pulp-fixtures@7ad87de