### PR TITLE
Adjust number of locally_stored_units on FixFileCorruptionTestCase.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
@@ -317,7 +317,7 @@ class FixFileCorruptionTestCase(BaseAPITestCase):
         """Assert all units are downloaded after download_repo finishes."""
         # Support for package langpacks has been added in Pulp 2.9. In earlier
         # versions, langpacks are ignored.
-        locally_stored_units = 39  # See repo['content_unit_counts']
+        locally_stored_units = 41  # See repo['content_unit_counts']
         if self.cfg.pulp_version >= Version('2.9'):
             locally_stored_units += 1
         self.assertEqual(


### PR DESCRIPTION
Adjust number according to new pulp-fixtures.

``` python
'content_unit_counts':{'erratum': 4,
                       'package_category': 1,
                       'package_group': 2,
                       'package_langpacks': 1,
                       'rpm': 34},

```
See: PulpQE/pulp-fixtures@7ad87de