### PR TITLE
Add name to yum configuration files

### DIFF
--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -242,6 +242,7 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
             enabled=1,
             gpgcheck=0,
             metadata_expire=0,  # force metadata to load every time
+            name=repo_id,
             repositoryid=repo_id,
             sslverify='yes' if verify else 'no',
         )


### PR DESCRIPTION
yum and/or dnf will raise a warning like the following if asked to parse
a configuration file (in `/etc/yum.repos.d/`) that doesn't contain a
name:

> stderr: Repository 'ba808d6e-274e-40a9-a342-026dd143e0bf' is missing
> name in configuration, using id.