### PR TITLE
Update feed url for test_copy_units.

### DIFF
--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from pulp_smash import cli, config, selectors, utils
 from pulp_smash.pulp2.utils import pulp_admin_login
 
-from pulp_2_tests.constants import RPM_SIGNED_FEED_URL
+from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
 from pulp_2_tests.tests.rpm.cli.utils import count_langpacks
 from pulp_2_tests.tests.rpm.utils import (
     check_issue_2277,
@@ -38,7 +38,7 @@ def setUpModule():  # pylint:disable=invalid-name
     pulp_admin_login(cfg)
     client.run(
         'pulp-admin rpm repo create --repo-id {} --feed {}'
-        .format(_REPO_ID, RPM_SIGNED_FEED_URL).split()
+        .format(_REPO_ID, RPM_UNSIGNED_FEED_URL).split()
     )
 
     # If setUpModule() fails, tearDownModule() isn't run. In addition, we can't


### PR DESCRIPTION
Neither `yum` or `dnf` were able to install packages from the
`rpm-signed` fixtures. This will require further investigation.
Meanwhile update the feed url for another pulp-fixtures without
compromise test results and test of features.