### PR TITLE
Adding logic for registering and updating consumers with client certs

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -38,6 +38,7 @@ Location: :doc:`/index` → :doc:`/tests`
     tests/pulp_2_tests.tests.platform.api_v2.test_repository
     tests/pulp_2_tests.tests.platform.api_v2.test_search
     tests/pulp_2_tests.tests.platform.api_v2.test_user
+    tests/pulp_2_tests.tests.platform.api_v2.utils
     tests/pulp_2_tests.tests.platform.cli
     tests/pulp_2_tests.tests.platform.cli.test_pulp_manage_db
     tests/pulp_2_tests.tests.platform.cli.test_selinux

--- a/docs/tests/pulp_2_tests.tests.platform.api_v2.utils.rst
+++ b/docs/tests/pulp_2_tests.tests.platform.api_v2.utils.rst
@@ -1,0 +1,6 @@
+`pulp_2_tests.tests.platform.api_v2.utils`
+==========================================
+
+Location: :doc:`/index` → :doc:`/tests` → :doc:`/tests/pulp_2_tests.tests.platform.api_v2.utils`
+
+.. automodule:: pulp_2_tests.tests.platform.api_v2.utils

--- a/pulp_2_tests/tests/platform/api_v2/test_consumer.py
+++ b/pulp_2_tests/tests/platform/api_v2/test_consumer.py
@@ -4,6 +4,8 @@
 .. _consumer:
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
 """
+import os
+import tempfile
 import unittest
 from urllib.parse import urljoin
 
@@ -12,6 +14,7 @@ from pulp_smash.pulp2.constants import CONSUMERS_PATH, REPOSITORY_PATH
 
 from pulp_2_tests.tests.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_2_tests.tests.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_2_tests.tests.platform.api_v2.utils import make_client_use_cert_auth
 
 
 class BindConsumerTestCase(unittest.TestCase):
@@ -67,3 +70,63 @@ class BindConsumerTestCase(unittest.TestCase):
             self.assertEqual(result['consumer_id'], consumer['consumer']['id'])
             self.assertEqual(result['distributor_id'], body['distributor_id'])
             self.assertEqual(result['repo_id'], body['repo_id'])
+
+
+class RegisterAndUpdateConsumerTestCase(unittest.TestCase):
+    """Show that one can `register and update a consumer`_.
+
+    The call to *consumer register api* should return a x.509 certificate,
+    that should be useful in updating a consumer and for other actions.
+
+    .. _register and update a consumer:
+        https://docs.pulpproject.org/dev-guide/integration/rest-api/consumer/cud.html#register-a-consumer
+    """
+
+    def test_all(self):
+        """Register and Update a consumer.
+
+        Do the following:
+
+        1. Register a consumer with the consumer API
+        2. Save the certificate returned in the response
+        3. Update the same consumer with new details by using the client certificates
+
+        Assert that:
+
+        * The response for registering a consumer has a x.509 certificate.
+        * The response body contains the correct values.
+
+        Refer:
+
+        * `Pulp Smash #1007 <https://github.com/PulpQE/pulp-smash/issues/1007>`_
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+        tmp_cert_file = tempfile.NamedTemporaryFile(delete=False)
+        self.addCleanup(os.unlink, tmp_cert_file.name)
+
+        # Step 1
+        consumer = client.post(CONSUMERS_PATH, {'id': utils.uuid4()})
+        self.addCleanup(client.delete, consumer['consumer']['_href'])
+        self.assertIn('certificate', consumer, 'certificate not found in the response')
+
+        # Step 2
+        with open(tmp_cert_file.name, 'w') as file_writer:
+            file_writer.write(consumer['certificate'])
+
+        # step 3
+        make_client_use_cert_auth(client, tmp_cert_file.name)
+        body = {
+            'delta': {
+                'display_name': 'Test Consumer',
+                'notes': {'arch': 'x86_64'},
+                'description': 'QA automation testing machine'
+            }
+        }
+        result = client.put(consumer['consumer']['_href'], body)
+        with self.subTest(comment='check display name'):
+            self.assertEqual(result['display_name'], body['delta']['display_name'])
+        with self.subTest(comment='check notes'):
+            self.assertEqual(result['notes'], body['delta']['notes'])
+        with self.subTest(comment='check description'):
+            self.assertEqual(result['description'], body['delta']['description'])

--- a/pulp_2_tests/tests/platform/api_v2/utils.py
+++ b/pulp_2_tests/tests/platform/api_v2/utils.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+"""Utility functions for Platform tests."""
+
+
+def make_client_use_cert_auth(client, cert):
+    """Make an API client use certificate authentication.
+
+    Mutate the given ``client`` by doing the following:
+
+    * Delete ``'auth'`` from the client's ``request_kwargs``. ``'auth'`` is
+      typcially a ``(username, password)`` tuple.
+    * Insert the given ``cert`` into the client's ``request_kwargs``.
+
+    :param client: An API client.
+    :param cert: Path to the Client Certificate file
+            that is used for authenticating the client
+    :returns: Nothing. The client is mutated in place.
+    """
+    del client.request_kwargs['auth']
+    client.request_kwargs['cert'] = cert


### PR DESCRIPTION
This commit adds a new testcase for registering and updating a consumer.
The Registering happens with basic auth url and the update is through
the client certificate that is in the previous response.

See PulpQE/pulp-smash#1007