### PR TITLE
Add basic test coverage for modular RPM repository.

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -77,6 +77,7 @@ Location: :doc:`/index` → :doc:`/tests`
     tests/pulp_2_tests.tests.rpm.api_v2.test_iso_crud
     tests/pulp_2_tests.tests.rpm.api_v2.test_iso_sync_publish
     tests/pulp_2_tests.tests.rpm.api_v2.test_mirrorlist
+    tests/pulp_2_tests.tests.rpm.api_v2.test_modularity
     tests/pulp_2_tests.tests.rpm.api_v2.test_no_op_publish
     tests/pulp_2_tests.tests.rpm.api_v2.test_orphan_remove
     tests/pulp_2_tests.tests.rpm.api_v2.test_package_paths

--- a/docs/tests/pulp_2_tests.tests.rpm.api_v2.test_modularity.rst
+++ b/docs/tests/pulp_2_tests.tests.rpm.api_v2.test_modularity.rst
@@ -1,0 +1,6 @@
+`pulp_2_tests.tests.rpm.api_v2.test_modularity`
+===============================================
+
+Location: :doc:`/index` → :doc:`/tests` → :doc:`/tests/pulp_2_tests.tests.rpm.api_v2.test_modularity`
+
+.. automodule:: pulp_2_tests.tests.rpm.api_v2.test_modularity

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+"""Tests that perform actions over RPM modular repositories."""
+import unittest
+
+from packaging.version import Version
+from pulp_smash import api, config
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import publish_repo, sync_repo
+
+from pulp_2_tests.constants import RPM_WITH_MODULES_FEED_URL
+from pulp_2_tests.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_repodata,
+)
+from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+
+
+class ManageModularContentTestCase(unittest.TestCase):
+    """Manage modular content tests cases.
+
+    This test targets the following issue:
+
+    `Pulp Smash #1122 <https://github.com/PulpQE/pulp-smash/issues/1122>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class wide variables."""
+        cls.cfg = config.get_config()
+        if cls.cfg.pulp_version < Version('2.17'):
+            raise unittest.SkipTest('This test requires Pulp 2.17 or newer.')
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    def test_sync_publish_repo(self):
+        """Test sync and publish modular RPM repository."""
+        body = gen_repo()
+        body['importer_config']['feed'] = RPM_WITH_MODULES_FEED_URL
+        body['distributors'] = [gen_distributor()]
+        repo = self.client.post(REPOSITORY_PATH, body)
+        self.addCleanup(self.client.delete, repo['_href'])
+        sync_repo(self.cfg, repo)
+        repo = self.client.get(repo['_href'], params={'details': True})
+
+        # Assert that `modulemd` and `modulemd_defaults` are present on the
+        # repository.
+        self.assertIsNotNone(repo['content_unit_counts']['modulemd'])
+        self.assertIsNotNone(repo['content_unit_counts']['modulemd_defaults'])
+
+        publish_repo(self.cfg, repo)
+
+        get_repodata(
+            self.cfg,
+            repo['distributors'][0],
+            'modules',
+            api.safe_handler,
+        )


### PR DESCRIPTION
Test sync and publish for modular RPM repository.

See:PulpQE/pulp-smash#1122