### PR TITLE
Remove duplicate line.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
@@ -212,7 +212,6 @@ class FastForwardIntegrityTestCase(unittest.TestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
         sync_repo(cfg, repo)
-        repo = client.get(repo['_href'], params={'details': True})
         return client.get(repo['_href'], params={'details': True})
 
     @staticmethod


### PR DESCRIPTION
There was a line identical to the next one.Remove one of them.
It was removed `repo = client.get(repo['_href'], params={'details':
True})`.