### PR TITLE
Add basic test coverage for rich and weak dependencies.

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -87,6 +87,7 @@ Location: :doc:`/index` → :doc:`/tests`
     tests/pulp_2_tests.tests.rpm.api_v2.test_repoview
     tests/pulp_2_tests.tests.rpm.api_v2.test_republish
     tests/pulp_2_tests.tests.rpm.api_v2.test_retain_old_count
+    tests/pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies
     tests/pulp_2_tests.tests.rpm.api_v2.test_rsync_distributor
     tests/pulp_2_tests.tests.rpm.api_v2.test_schedule_publish
     tests/pulp_2_tests.tests.rpm.api_v2.test_schedule_sync

--- a/docs/tests/pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies.rst
+++ b/docs/tests/pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies.rst
@@ -1,0 +1,6 @@
+`pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies`
+===========================================================
+
+Location: :doc:`/index` → :doc:`/tests` → :doc:`/tests/pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies`
+
+.. automodule:: pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies

--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -462,6 +462,9 @@ RPM_PKGLISTS_UPDATEINFO_FEED_URL = (
 )
 """A repository whose updateinfo file has multiple ``<pkglist>`` sections."""
 
+RPM_RICH_WEAK_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-richnweak-deps/')
+"""The URL to an RPM repository with weak and rich dependencies."""
+
 RPM_SIGNED_FEED_COUNT = 34
 """The number of packages available at :data:`RPM_SIGNED_FEED_URL`."""
 
@@ -528,6 +531,9 @@ RPM_WITH_VENDOR_URL = urljoin(
     'rpm-with-vendor-1-1.fc25.noarch.rpm'
 )
 """The URL of an RPM with a specified vendor in its header."""
+
+SRPM_RICH_WEAK_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-richnweak-deps/')
+"""The URL to an SRPM repository with weak and rich dependencies."""
 
 SRPM = 'test-srpm02-1.0-1.src.rpm'
 """An SRPM file at :data:`pulp_2_tests.constants.SRPM_SIGNED_FEED_URL`."""

--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+"""Test actions over repositories with rich and weak dependencies."""
+import unittest
+
+from packaging.version import Version
+from pulp_smash import api, config
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.utils import publish_repo, sync_repo
+
+from pulp_2_tests.constants import (
+    RPM_RICH_WEAK_FEED_URL,
+    SRPM_RICH_WEAK_FEED_URL,
+)
+from pulp_2_tests.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+
+
+class SyncPublishTestCase(unittest.TestCase):
+    """Sync and publish a repository with rich and weak dependencies."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        if cls.cfg.pulp_version < Version('2.17'):
+            raise unittest.SkipTest('This test requires Pulp 2.17 or newer.')
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    def test_rpm(self):
+        """Sync and publish an RPM repo. See :meth:`do_test`."""
+        self.do_test(RPM_RICH_WEAK_FEED_URL)
+
+    def test_srpm(self):
+        """Sync and publish an SRPM repo. See :meth:`do_test`."""
+        self.do_test(SRPM_RICH_WEAK_FEED_URL)
+
+    def do_test(self, feed):
+        """Sync and publish a repository with rich and weak dependencies.
+
+        This test targets the following issue:
+
+        `Pulp Smash #901 <https://github.com/PulpQE/pulp-smash/issues/901>`_.
+        """
+        body = gen_repo(
+            importer_config={'feed': feed},
+            distributors=[gen_distributor()]
+        )
+        repo = self.client.post(REPOSITORY_PATH, body)
+        self.addCleanup(self.client.delete, repo['_href'])
+        sync_repo(self.cfg, repo)
+        repo = self.client.get(repo['_href'], params={'details': True})
+        with self.subTest(comment='verify last_publish after sync'):
+            self.assertIsNone(repo['distributors'][0]['last_publish'])
+        publish_repo(self.cfg, repo)
+        repo = self.client.get(repo['_href'], params={'details': True})
+        with self.subTest(comment='verify last_publish after publish'):
+            self.assertIsNotNone(repo['distributors'][0]['last_publish'])


### PR DESCRIPTION
Add basic test coverage to sync and publish repositories,RPM and SRPM,
with rich and weak dependencies.

Moreover, add two new constants: `RPM_RICH_WEAK_FEED_URL` and
`SRPM_RICH_WEAK_FEED_URL`.

https://github.com/PulpQE/pulp-smash/issues/901