### PR TITLE
Fix units counts in the RetainOldCountTestCase.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_retain_old_count.py
@@ -59,7 +59,7 @@ class RetainOldCountTestCase(BaseAPITestCase):
         """
         repo = self.create_sync_repo(0)
         counts = [_['content_unit_counts']['rpm'] for _ in (self.repo, repo)]
-        self.assertEqual(counts[0] - 3, counts[1])
+        self.assertEqual(counts[0] - 4, counts[1])
 
     def test_retain_one(self):
         """Give ``retain_old_count`` a value of one.
@@ -71,7 +71,7 @@ class RetainOldCountTestCase(BaseAPITestCase):
         """
         repo = self.create_sync_repo(1)
         counts = [_['content_unit_counts']['rpm'] for _ in (self.repo, repo)]
-        self.assertEqual(counts[0], counts[1])
+        self.assertEqual(counts[0] - 1, counts[1])
 
     def create_sync_repo(self, retain_old_count):
         """Create and sync a repository. Return detailed information about it.


### PR DESCRIPTION
Adjust number per new fixtures.

See: https://github.com/PulpQE/pulp-fixtures/pull/94

`self.assertEqual(counts[0] - 4, counts[1])` there are 4 extra versions
for the following packages: Walrus, Duck and Kangaroo.

`self.assertEqual(counts[0] - 1, counts[1])` the package Duck has 2
extra versions. Then `retain_old_count` is keeping just one. Remove the
extra one.