### PR TITLE
Elevating user privileges if the cli is root for errta testcase

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_errata.py
@@ -104,7 +104,8 @@ class ApplyErratumTestCase(unittest.TestCase):
         self.assertIn(yum_or_dnf, ('yum', 'dnf'))
         if yum_or_dnf == 'yum':
             return ('--advisory', erratum)
-        lines = cli.Client(cfg).run((
+        sudo = () if cli.is_root(cfg) else ('sudo',)
+        lines = cli.Client(cfg).run(sudo + (
             'dnf', '--quiet', 'updateinfo', 'list', erratum
         )).stdout.strip().splitlines()
         return tuple((line.split()[2] for line in lines))


### PR DESCRIPTION
The `_get_upgrade_targets` method is throwing a non-zero return code
after executing the `updateinfo` cmd. Elevating root privileges if the
cfg is configured as root user.