### PR TITLE
Add test to upload RPM rich/weak dependencies to a repo.

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -323,6 +323,12 @@ RPM2 = '{}-{}{}-{}.{}.rpm'.format(
 )
 """The name of an RPM. See :data:`pulp_2_tests.constants.RPM2_UNSIGNED_URL`."""
 
+RPM_RICH_WEAK = 'PanAmerican-1-0.noarch.rpm'
+"""The path to an RPM with rich/weak dependency in one of the RPM repositories.
+
+This path may be joined with :data:`RPM_RICH_WEAK_FEED_URL`.
+"""
+
 RPM_WITH_VENDOR_DATA = MappingProxyType({
     'name': 'rpm-with-vendor',
     'epoch': '0',

--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -1,13 +1,20 @@
 # coding=utf-8
 """Test actions over repositories with rich and weak dependencies."""
 import unittest
+from urllib.parse import urljoin
 
 from packaging.version import Version
-from pulp_smash import api, config
+from pulp_smash import api, config, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import publish_repo, sync_repo
+from pulp_smash.pulp2.utils import (
+    publish_repo,
+    search_units,
+    sync_repo,
+    upload_import_unit,
+)
 
 from pulp_2_tests.constants import (
+    RPM_RICH_WEAK,
     RPM_RICH_WEAK_FEED_URL,
     SRPM_RICH_WEAK_FEED_URL,
 )
@@ -55,3 +62,35 @@ class SyncPublishTestCase(unittest.TestCase):
         repo = self.client.get(repo['_href'], params={'details': True})
         with self.subTest(comment='verify last_publish after publish'):
             self.assertIsNotNone(repo['distributors'][0]['last_publish'])
+
+
+class UploadRPMTestCase(unittest.TestCase):
+    """Test whether one can upload a RPM with rich/weak into a repository.
+
+    Specifically, this method does the following:
+
+    1. Create an RPM repository.
+    2. Upload an RPM with rich/weak dependencies into the repository.
+    3. Search for all content units in the repository.
+    """
+
+    def test_all(self):
+        """Import a RPM with rich/weak dependencies into a repository.
+
+        Search it for content units.
+        """
+        cfg = config.get_config()
+        if cfg.pulp_version < Version('2.17'):
+            raise unittest.SkipTest('This test requires Pulp 2.17 or newer.')
+        client = api.Client(cfg, api.json_handler)
+        repo = client.post(REPOSITORY_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        rpm = utils.http_get(urljoin(RPM_RICH_WEAK_FEED_URL + '/', RPM_RICH_WEAK))
+        upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)
+        units = search_units(cfg, repo)
+
+        # Test if RPM has been uploaded successfully
+        self.assertEqual(len(units), 1)
+
+        # Test if RPM extracted correct metadata for creating filename
+        self.assertEqual(units[0]['metadata']['filename'], RPM_RICH_WEAK)


### PR DESCRIPTION
Add test to upload an RPM with rich/weak dependencies to a repository.

Moreover, add a new constant, `RPM_RICH_WEAK`.

See:https://github.com/PulpQE/pulp-smash/issues/901