### PR TITLE
Verify whether package manager read module list.

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -121,6 +121,12 @@ FILE2_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 FILE2_URL = urljoin(FILE2_FEED_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE2_FEED_URL`."""
 
+MODULE_FIXTURES_PACKAGES = {'duck': 3, 'kangaroo': 2, 'walrus': 2}
+"""The name and the number of the package versions listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
+"""
+
 OPENSUSE_FEED_URL = 'https://download.opensuse.org/update/leap/42.3/oss/'
 """The URL to an openSUSE repository.
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -1,17 +1,25 @@
 # coding=utf-8
 """Tests that perform actions over RPM modular repositories."""
 import unittest
+from urllib.parse import urljoin
 
 from packaging.version import Version
-from pulp_smash import api, config
+from pulp_smash import api, cli, config
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
-from pulp_2_tests.constants import RPM_WITH_MODULES_FEED_URL
+from pulp_2_tests.constants import (
+    MODULE_FIXTURES_PACKAGES,
+    RPM_WITH_MODULES_FEED_URL,
+)
 from pulp_2_tests.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
     get_repodata,
+)
+from pulp_2_tests.tests.rpm.utils import (
+    gen_yum_config_file,
+    os_support_modularity,
 )
 from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
@@ -55,3 +63,50 @@ class ManageModularContentTestCase(unittest.TestCase):
             'modules',
             api.safe_handler,
         )
+
+
+class PackageManagerModuleListTestCase(unittest.TestCase):
+    """Package manager can read module list from a Pulp repo."""
+
+    def test_all(self):
+        """Verify whether package manager can read module list from a Pulp repo."""
+        cfg = config.get_config()
+        if cfg.pulp_version < Version('2.17'):
+            raise unittest.SkipTest('This test requires at least Pulp 2.17 or newer.')
+        if not os_support_modularity(cfg):
+            raise unittest.SkipTest('This test requires an OS that supports modularity.')
+        client = api.Client(cfg, api.json_handler)
+        body = gen_repo(
+            importer_config={'feed': RPM_WITH_MODULES_FEED_URL},
+            distributors=[gen_distributor()]
+        )
+
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
+        sync_repo(cfg, repo)
+        publish_repo(cfg, repo)
+        repo = client.get(repo['_href'], params={'details': True})
+        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
+        sudo = () if cli.is_root(cfg) else ('sudo',)
+        repo_path = gen_yum_config_file(
+            cfg,
+            baseurl=urljoin(cfg.get_base_url(), urljoin(
+                'pulp/repos/',
+                repo['distributors'][0]['config']['relative_url']
+            )),
+            name=repo['_href'],
+            enabled=1,
+            gpgcheck=0,
+            metadata_expire=0,  # force metadata to load every time
+            repositoryid=repo['id'],
+            sslverify='yes' if verify else 'no',
+        )
+        self.addCleanup(cli.Client(cfg).run, sudo + ('rm', repo_path))
+        lines = cli.Client(cfg).run((
+            'dnf', 'module', 'list', '--all'
+        )).stdout.splitlines()
+        for key, value in MODULE_FIXTURES_PACKAGES.items():
+            with self.subTest(package=key):
+                module = [line for line in lines if key in line]
+                self.assertEqual(len(module), value, module)

--- a/pulp_2_tests/tests/rpm/utils.py
+++ b/pulp_2_tests/tests/rpm/utils.py
@@ -208,6 +208,18 @@ def gen_yum_config_file(cfg, repositoryid, **kwargs):
     return path
 
 
+def os_support_modularity(cfg, pulp_host=None):
+    """Return ``True`` if the server `supports modularity`_, or ``False`` otherwise.
+
+    .. _supports modularity: https://fedoraproject.org/wiki/Changes/F28AddonModularity
+
+    :param cfg: Information about the system being targeted.
+    :returns: True or False.
+    """
+    return (utils.get_os_release_id(cfg, pulp_host) == 'fedora' and
+            utils.get_os_release_version_id(cfg, pulp_host) >= '28')
+
+
 skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
 """The ``@skip_if`` decorator, customized for unittest.
 


### PR DESCRIPTION
Add test to verify whether package manager can read module list from a
repository provided by Pulp.

Add an utils function to `rpm/utils`: `os_support_modularity`.

See: https://fedoraproject.org/wiki/Changes/F28AddonModularity

Related: https://github.com/PulpQE/pulp-smash/issues/1122

Also: https://github.com/PulpQE/pulp-fixtures/pull/84