### PR TITLE
Adding Sync Copy testcase to RPM modularity test

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -127,6 +127,17 @@ MODULE_FIXTURES_PACKAGES = {'duck': 3, 'kangaroo': 2, 'walrus': 2}
 .. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
 """
 
+MODULE_FIXTURES_PACKAGE_STREAMS = {
+    'walrus': {
+        'stream': '0.71',
+        'rpm_count': 4,
+        'total_available_units': 5,
+    }}
+"""The name and the stream of the package listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
+"""
+
 OPENSUSE_FEED_URL = 'https://download.opensuse.org/update/leap/42.3/oss/'
 """The URL to an openSUSE repository.
 


### PR DESCRIPTION
This commit deals with creating two repos, where one repo is synced with
modular content. The first repo is then copied into a second one and the
second repo is tested whether it has modular content.