### PR TITLE
Added test for issue 3929 - Asserts Recommends field is displayed

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -106,6 +106,7 @@ Location: :doc:`/index` → :doc:`/tests`
     tests/pulp_2_tests.tests.rpm.api_v2.utils
     tests/pulp_2_tests.tests.rpm.cli
     tests/pulp_2_tests.tests.rpm.cli.test_character_encoding
+    tests/pulp_2_tests.tests.rpm.cli.test_content
     tests/pulp_2_tests.tests.rpm.cli.test_copy_units
     tests/pulp_2_tests.tests.rpm.cli.test_environments
     tests/pulp_2_tests.tests.rpm.cli.test_langpacks

--- a/docs/tests/pulp_2_tests.tests.rpm.cli.test_content.rst
+++ b/docs/tests/pulp_2_tests.tests.rpm.cli.test_content.rst
@@ -1,0 +1,6 @@
+`pulp_2_tests.tests.rpm.cli.test_content`
+=========================================
+
+Location: :doc:`/index` → :doc:`/tests` → :doc:`/tests/pulp_2_tests.tests.rpm.cli.test_content`
+
+.. automodule:: pulp_2_tests.tests.rpm.cli.test_content

--- a/pulp_2_tests/tests/rpm/cli/test_content.py
+++ b/pulp_2_tests/tests/rpm/cli/test_content.py
@@ -1,0 +1,66 @@
+"""Tests search of the contents of a repository."""
+import unittest
+
+from packaging.version import Version
+
+from pulp_smash import cli, config, utils
+from pulp_smash.pulp2.utils import pulp_admin_login
+
+from pulp_2_tests.constants import RPM_RICH_WEAK_FEED_URL
+from pulp_2_tests.tests.rpm.cli.utils import sync_repo
+from pulp_2_tests.tests.rpm.utils import rpm_rich_weak_dependencies
+from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+
+
+class RichWeakTestCase(unittest.TestCase):
+    """Search for contents in a Rich/Weak repository.
+
+    This test targets `Pulp #3929`_ and `Pulp Smash #901`_. The
+    `repository content`_ documentation describes the CLI content syntax.
+
+    .. _Pulp #3929:  https://pulp.plan.io/issues/3929
+    .. _Pulp Smash #901: https://github.com/PulpQE/pulp-smash/issues/901
+    .. _repository content:
+        https://docs.pulpproject.org/en/latest/user-guide/admin-client/repositories.html#content-search
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a repository."""
+        cfg = config.get_config()
+        if cfg.pulp_version < Version('2.17'):
+            raise unittest.SkipTest('This test requires Pulp 2.17 or newer.')
+        if not rpm_rich_weak_dependencies(cfg):
+            raise unittest.SkipTest('This test requires RPM 4.12 or newer.')
+        pulp_admin_login(cfg)
+        cls.client = cli.Client(cfg)
+        cls.repo_id = utils.uuid4()
+        cls.client.run(
+            'pulp-admin rpm repo create --repo-id {0} '
+            '--relative-url {0} --feed {1}'
+            .format(cls.repo_id, RPM_RICH_WEAK_FEED_URL).split()
+        )
+        sync_repo(cfg, cls.repo_id)
+
+    def test_positive_shows_required_fields(self):
+        """Search contents of a richnweak repository matching package name.
+
+        Asserts the required fields are present.
+        """
+        result = self.client.run(
+            'pulp-admin rpm repo content rpm --repo-id {} '
+            '--match name=Cobbler'
+            .format(self.repo_id).split()
+        )
+        required_fields = ('Recommends:', 'Requires:', 'Provides:')
+        for field in required_fields:
+            with self.subTest(field=field):
+                self.assertEqual(result.stdout.count(field), 1, result)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Delete the repository created by :meth:`setUpClass`."""
+        cls.client.run(
+            'pulp-admin rpm repo delete --repo-id {}'
+            .format(cls.repo_id).split()
+        )

--- a/pulp_2_tests/tests/rpm/cli/test_sync.py
+++ b/pulp_2_tests/tests/rpm/cli/test_sync.py
@@ -7,6 +7,7 @@ from pulp_smash import cli, config, selectors, utils
 from pulp_smash.pulp2.utils import pulp_admin_login, reset_pulp
 
 from pulp_2_tests.constants import RPM_UNSIGNED_FEED_URL
+from pulp_2_tests.tests.rpm.cli.utils import sync_repo
 from pulp_2_tests.tests.rpm.utils import check_issue_2620, set_up_module
 
 
@@ -168,18 +169,3 @@ def get_rpm_names(cfg, repo_id):
         line.split(keyword)[1].strip() for line in proc.stdout.splitlines()
         if keyword in line
     ]
-
-
-def sync_repo(cfg, repo_id, force_sync=False):
-    """Sync an RPM repository.
-
-    :param cfg: Information about a Pulp
-        deployment.
-    :param repo_id: A RPM repository ID.
-    :param repo_id: A boolean flag to denote if is a force-full sync.
-    :returns: A ``pulp_smash.cli.CompletedProcess``.
-    """
-    cmd = ['pulp-admin', 'rpm', 'repo', 'sync', 'run', '--repo-id', repo_id]
-    if force_sync:
-        cmd.append('--force-full')
-    return cli.Client(cfg).run(cmd)

--- a/pulp_2_tests/tests/rpm/cli/utils.py
+++ b/pulp_2_tests/tests/rpm/cli/utils.py
@@ -27,3 +27,18 @@ def count_langpacks(cfg, repo_id):
     if lines:
         return int(lines[0].split(keyword)[1].strip())
     return 0
+
+
+def sync_repo(cfg, repo_id, force_sync=False):
+    """Sync an RPM repository.
+
+    :param cfg: Information about a Pulp
+        deployment.
+    :param repo_id: A RPM repository ID.
+    :param repo_id: A boolean flag to denote if is a force-full sync.
+    :returns: A ``pulp_smash.cli.CompletedProcess``.
+    """
+    cmd = ['pulp-admin', 'rpm', 'repo', 'sync', 'run', '--repo-id', repo_id]
+    if force_sync:
+        cmd.append('--force-full')
+    return cli.Client(cfg).run(cmd)


### PR DESCRIPTION
This test targets:

Pulp issue: https://pulp.plan.io/issues/3929

And https://github.com/PulpQE/pulp-smash/issues/901

Asserts that a `content` search on a ricknweak repository shows required `Recommends`, `Requires` and `Provides` fields.