### PR TITLE
Refactored `gen_yum_config_file` function with common defaults and required fields.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_errata.py
@@ -75,7 +75,6 @@ class ApplyErratumTestCase(unittest.TestCase):
 
         Also, schedule it for deletion. Return nothing.
         """
-        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
         sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
@@ -84,11 +83,7 @@ class ApplyErratumTestCase(unittest.TestCase):
                 repo['distributors'][0]['config']['relative_url']
             )),
             name=repo['_href'],
-            enabled=1,
-            gpgcheck=0,
-            metadata_expire=0,  # force metadata to load every time
-            repositoryid=repo['id'],
-            sslverify='yes' if verify else 'no',
+            repositoryid=repo['id']
         )
         self.addCleanup(cli.Client(cfg).run, sudo + ('rm', repo_path))
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -181,7 +181,6 @@ class PackageManagerModuleListTestCase(unittest.TestCase):
         sync_repo(cfg, repo)
         publish_repo(cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
-        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
         sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
@@ -190,11 +189,7 @@ class PackageManagerModuleListTestCase(unittest.TestCase):
                 repo['distributors'][0]['config']['relative_url']
             )),
             name=repo['_href'],
-            enabled=1,
-            gpgcheck=0,
-            metadata_expire=0,  # force metadata to load every time
-            repositoryid=repo['id'],
-            sslverify='yes' if verify else 'no',
+            repositoryid=repo['id']
         )
         cli_client = cli.Client(cfg)
         self.addCleanup(cli_client.run, sudo + ('rm', repo_path))

--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -121,7 +121,6 @@ class PackageManagerCosumeRPMTestCase(unittest.TestCase):
         repo = client.get(repo['_href'], params={'details': True})
         sync_repo(cfg, repo)
         publish_repo(cfg, repo)
-        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
         sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
@@ -130,11 +129,7 @@ class PackageManagerCosumeRPMTestCase(unittest.TestCase):
                 repo['distributors'][0]['config']['relative_url']
             )),
             name=repo['_href'],
-            enabled=1,
-            gpgcheck=0,
-            metadata_expire=0,  # force metadata to load every time
-            repositoryid=repo['id'],
-            sslverify='yes' if verify else 'no',
+            repositoryid=repo['id']
         )
         cli_client = cli.Client(cfg)
         self.addCleanup(cli_client.run, sudo + ('rm', repo_path))

--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -223,7 +223,6 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
         client = cli.Client(cfg)
         pkg_mgr = cli.PackageManager(cfg)
         sudo = () if cli.is_root(cfg) else ('sudo',)
-        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
 
         # Create the second repository.
         repo_id = self.create_repo(cfg)
@@ -239,12 +238,8 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
         repo_path = gen_yum_config_file(
             cfg,
             baseurl=urljoin(cfg.get_base_url(), 'pulp/repos/' + repo_id),
-            enabled=1,
-            gpgcheck=0,
-            metadata_expire=0,  # force metadata to load every time
             name=repo_id,
-            repositoryid=repo_id,
-            sslverify='yes' if verify else 'no',
+            repositoryid=repo_id
         )
         self.addCleanup(client.run, sudo + ('rm', repo_path))
         pkg_mgr.install(rpm_name)


### PR DESCRIPTION
Following our `less boilerplate` effort.

The function `gen_yum_config_file` required some boilerplate and repetitive code that is used across the 4 occurrences of it being used.

I re factored the function to assume some common use defaults and avoiding the need to calculate the `verify` status before each call encapsulating this logic but allowing it to be overwritten. 

The function now takes only 3 required options `repositoryid`, `name`, and `baseurl`, as the other options are commonly repeated it is assumed as default ex: `enabled=1` is almost always the same value.

The `sslverify` is now inferred com the passed `cfg` the same way it was done before but now it is encapsulated inside the function.

All the arguments can still be overwritten.

All references updated and tests passing:

```bash
$ git grep 'gen_yum_config_file('
pulp_2_tests/tests/rpm/api_v2/test_errata.py:        repo_path = gen_yum_config_file(
pulp_2_tests/tests/rpm/api_v2/test_modularity.py:        repo_path = gen_yum_config_file(
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py:        repo_path = gen_yum_config_file(
pulp_2_tests/tests/rpm/cli/test_copy_units.py:        repo_path = gen_yum_config_file(

$ py.test --pyargs $(git grep --files-with-matches 'gen_yum_config_file(')
collected 4 items
pulp_2_tests/tests/rpm/api_v2/test_errata.py::ApplyErratumTestCase::test_all PASSED
pulp_2_tests/tests/rpm/api_v2/test_modularity.py::PackageManagerModuleListTestCase::test_all PASSED
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::PackageManagerCosumeRPMTestCase::test_all PASSED
pulp_2_tests/tests/rpm/cli/test_copy_units.py::UpdateRpmTestCase::test_all PASSED
```