### PR TITLE
Used `sudo=True` argument on calls to `cli.Client.run`

### DIFF
--- a/pulp_2_tests/tests/docker/utils.py
+++ b/pulp_2_tests/tests/docker/utils.py
@@ -51,6 +51,7 @@ def write_manifest_list(cfg, manifest_list):
     dir_path = client.run('mktemp --directory'.split()).stdout.strip()
     file_path = os.path.join(dir_path, utils.uuid4() + '.json')
     manifest_list_json = json.dumps(manifest_list)
+    # machine.session is used here to keep SSH session open
     client.machine.session().run(
         "{} echo '{}' > {}".format(
             sudo,

--- a/pulp_2_tests/tests/platform/cli/test_pulp_manage_db.py
+++ b/pulp_2_tests/tests/platform/cli/test_pulp_manage_db.py
@@ -48,8 +48,7 @@ class BaseTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         if not selectors.bug_is_fixed(2186, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2186')
-        cls.cmd = () if cli.is_root(cls.cfg) else ('sudo',)
-        cls.cmd += (
+        cls.cmd = (
             'runuser', '--shell', '/bin/sh', '--command', 'pulp-manage-db',
             '-', 'apache'
         )
@@ -71,18 +70,17 @@ class PositiveTestCase(BaseTestCase):
             'pulp_resource_manager',
             'pulp_workers',
         ))
-        cli.Client(self.cfg).run(self.cmd)
+        cli.Client(self.cfg).run(self.cmd, sudo=True)
 
     def test_dry_run(self):
         """Make sure pulp-manage-db runs if --dry-run is passed."""
         if not selectors.bug_is_fixed(2776, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2776')
-        cmd = () if cli.is_root(self.cfg) else ('sudo',)
-        cmd += (
+        cmd = (
             'runuser', '--shell', '/bin/sh', '--command',
             'pulp-manage-db --dry-run', '-', 'apache'
         )
-        cli.Client(self.cfg).run(cmd)
+        cli.Client(self.cfg).run(cmd, sudo=True)
 
 
 class NegativeTestCase(BaseTestCase):

--- a/pulp_2_tests/tests/platform/cli/test_selinux.py
+++ b/pulp_2_tests/tests/platform/cli/test_selinux.py
@@ -53,11 +53,10 @@ class ProcessLabelsTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Get all of the processes running on the target Pulp system."""
         cfg = config.get_config()
-        cmd = [] if cli.is_root(config.get_config()) else ['sudo']
-        cmd.extend(('ps', '-A', '-w', '-w', '-o', ','.join(PS_FIELDS)))
+        cmd = ('ps', '-A', '-w', '-w', '-o', ','.join(PS_FIELDS))
         cls.procs = [
             Process(*line.split(maxsplit=1))
-            for line in cli.Client(cfg).run(cmd).stdout.splitlines()
+            for line in cli.Client(cfg).run(cmd, sudo=True).stdout.splitlines()
         ]
 
     def _do_test(self, label, arg):
@@ -135,12 +134,12 @@ class FileLabelsTestCase(unittest.TestCase):
         #     # file: etc/passwd
         #     security.selinux="system_u:object_r:passwd_file_t:s0"
         #
-        cmd = [] if cli.is_root(config.get_config()) else ['sudo']
+        cmd = []
         cmd.extend(('getfattr', '--name=security.selinux'))
         if recursive:
             cmd.append('--recursive')
         cmd.append(file_)
-        lines = self.client.run(cmd).stdout.splitlines()
+        lines = self.client.run(cmd, sudo=True).stdout.splitlines()
         matches = 0
         getfattr_file = None  # tracks file currently under consideration
         for line in lines:

--- a/pulp_2_tests/tests/rpm/api_v2/test_content_sources.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_content_sources.py
@@ -72,8 +72,7 @@ class ValidHeadersTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Destroy the created content source."""
-        sudo = () if cli.is_root(cls.cfg) else ('sudo',)
-        cli.Client(cls.cfg).run(sudo + ('rm', '-f', cls.cs_path))
+        cli.Client(cls.cfg).run(('rm', '-f', cls.cs_path), sudo=True)
 
 
 class InvalidHeadersTestCase(unittest.TestCase):
@@ -122,8 +121,7 @@ class InvalidHeadersTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Destroy the created content source."""
-        sudo = () if cli.is_root(cls.cfg) else ('sudo',)
-        cli.Client(cls.cfg).run(sudo + ('rm', '-f', cls.cs_path))
+        cli.Client(cls.cfg).run(('rm', '-f', cls.cs_path), sudo=True)
 
 
 def _gen_content_source(cfg, content_source_body):
@@ -136,6 +134,7 @@ def _gen_content_source(cfg, content_source_body):
     sudo = '' if cli.is_root(cfg) else 'sudo'
     path = os.path.join(CONTENT_SOURCES_PATH, utils.uuid4() + '.conf')
     client = cli.Client(cfg)
+    # machine.session is used here to keep SSH session open
     client.machine.session().run(
         "{} bash -c \"echo >'{}' '{}'\""
         .format(sudo, path, content_source_body)

--- a/pulp_2_tests/tests/rpm/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_copy.py
@@ -118,6 +118,7 @@ class MtimeTestCase(unittest.TestCase):
             repo['distributors'][0]['config']['relative_url'],
             'repodata',
         ))
+        # machine.session is used here to keep SSH session open
         mtimes_pre = (
             cli_client.machine.session().run(cmd)[1].strip().split().sort()
         )
@@ -129,6 +130,7 @@ class MtimeTestCase(unittest.TestCase):
 
         # Get the mtime of the sqlite files again.
         time.sleep(1)
+        # machine.session is used here to keep SSH session open
         mtimes_post = (
             cli_client.machine.session().run(cmd)[1].strip().split().sort()
         )

--- a/pulp_2_tests/tests/rpm/api_v2/test_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_crud.py
@@ -108,28 +108,27 @@ class PulpDistributionTestCase(BaseAPITestCase):
         self.assertEqual(repo['content_unit_counts']['distribution'], 1)
         cli_client = cli.Client(self.cfg, cli.code_handler)
         relative_url = repo['distributors'][0]['config']['relative_url']
-        sudo = () if cli.is_root(self.cfg) else ('sudo',)
-        pulp_distribution = cli_client.run(sudo + (
+        pulp_distribution = cli_client.run((
             'cat',
             os.path.join(
                 '/var/lib/pulp/published/yum/http/repos/',
                 relative_url,
                 'PULP_DISTRIBUTION.xml',
             ),
-        )).stdout
+        ), sudo=True).stdout
         # make sure published repository PULP_DISTRIBUTION.xml does not include
         # any extra file from the original repo's PULP_DISTRIBUTION.xml under
         # metadata directory
         self.assertNotIn('metadata/productid', pulp_distribution)
 
-        release_info = cli_client.run(sudo + (
+        release_info = cli_client.run((
             'cat',
             os.path.join(
                 '/var/lib/pulp/published/yum/http/repos/',
                 relative_url,
                 'release-notes/release-info',
             ),
-        )).stdout
+        ), sudo=True).stdout
         response = requests.get(urljoin(
             urljoin(RPM_WITH_PULP_DISTRIBUTION_FEED_URL, 'release-notes/'),
             'release-info',

--- a/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_download_policies.py
@@ -286,26 +286,32 @@ class FixFileCorruptionTestCase(unittest.TestCase):
         # Trigger a repository download. Read the repo before and after.
         download_path = urljoin(cls.repo['_href'], 'actions/download/')
         params = {'details': True}
-        cls.repo_pre_download = api_client.get(cls.repo['_href'], params=params)
+        cls.repo_pre_download = api_client.get(
+            cls.repo['_href'], params=params)
         api_client.post(download_path, {'verify_all_units': False})
-        cls.repo_post_download = api_client.get(cls.repo['_href'], params=params)
+        cls.repo_post_download = api_client.get(
+            cls.repo['_href'], params=params)
 
         # Corrupt an RPM. The file is there, but the checksum isn't right.
         rpm_abs_path = cls.get_rpm_abs_path()
         cli_client = cli.Client(cls.cfg)
-        sudo = '' if cli.is_root(cls.cfg) else 'sudo '
-        checksum_cmd = (sudo + 'sha256sum ' + rpm_abs_path).split()
-        cls.sha_pre_corruption = cli_client.run(checksum_cmd).stdout.strip()
-        cli_client.run((sudo + 'rm ' + rpm_abs_path).split())
-        cli_client.run((sudo + 'touch ' + rpm_abs_path).split())
-        cli_client.run((sudo + 'chown apache:apache ' + rpm_abs_path).split())
-        cls.sha_post_corruption = cli_client.run(checksum_cmd).stdout.strip()
+        checksum_cmd = ('sha256sum ' + rpm_abs_path).split()
+        cls.sha_pre_corruption = cli_client.run(
+            checksum_cmd, sudo=True).stdout.strip()
+        cli_client.run(('rm ' + rpm_abs_path).split(), sudo=True)
+        cli_client.run(('touch ' + rpm_abs_path).split(), sudo=True)
+        cli_client.run(
+            ('chown apache:apache ' + rpm_abs_path).split(), sudo=True)
+        cls.sha_post_corruption = cli_client.run(
+            checksum_cmd, sudo=True).stdout.strip()
 
         # Trigger repository downloads that don't and do checksum files, resp.
         api_client.post(download_path, {'verify_all_units': False})
-        cls.unverified_file_sha = cli_client.run(checksum_cmd).stdout.strip()
+        cls.unverified_file_sha = cli_client.run(
+            checksum_cmd, sudo=True).stdout.strip()
         api_client.post(download_path, {'verify_all_units': True})
-        cls.verified_file_sha = cli_client.run(checksum_cmd).stdout.strip()
+        cls.verified_file_sha = cli_client.run(
+            checksum_cmd, sudo=True).stdout.strip()
 
     @classmethod
     def tearDownClass(cls):

--- a/pulp_2_tests/tests/rpm/api_v2/test_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_errata.py
@@ -75,7 +75,6 @@ class ApplyErratumTestCase(unittest.TestCase):
 
         Also, schedule it for deletion. Return nothing.
         """
-        sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
             baseurl=urljoin(cfg.get_base_url(), urljoin(
@@ -85,7 +84,7 @@ class ApplyErratumTestCase(unittest.TestCase):
             name=repo['_href'],
             repositoryid=repo['id']
         )
-        self.addCleanup(cli.Client(cfg).run, sudo + ('rm', repo_path))
+        self.addCleanup(cli.Client(cfg).run, ('rm', repo_path), sudo=True)
 
     def _get_upgrade_targets(self, cfg):
         """Get a tuple of upgrade targets for erratum RHEA-2012:0055."""
@@ -99,10 +98,9 @@ class ApplyErratumTestCase(unittest.TestCase):
         self.assertIn(yum_or_dnf, ('yum', 'dnf'))
         if yum_or_dnf == 'yum':
             return ('--advisory', erratum)
-        sudo = () if cli.is_root(cfg) else ('sudo',)
-        lines = cli.Client(cfg).run(sudo + (
+        lines = cli.Client(cfg).run((
             'dnf', '--quiet', 'updateinfo', 'list', erratum
-        )).stdout.strip().splitlines()
+        ), sudo=True).stdout.strip().splitlines()
         return tuple((line.split()[2] for line in lines))
 
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_sync_publish.py
@@ -117,11 +117,10 @@ class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):
 
         # Verify the correct units are on the remote system.
         cli_client = cli.Client(self.cfg)
-        sudo = () if cli.is_root(self.cfg) else ('sudo',)
         path = dists['iso_rsync_distributor']['config']['remote']['root']
         path = os.path.join(path, 'content/units')
-        cmd = sudo + ('find', path, '-name', '*.iso')
-        files = cli_client.run(cmd).stdout.strip().split('\n')
+        cmd = ('find', path, '-name', '*.iso')
+        files = cli_client.run(cmd, sudo=True).stdout.strip().split('\n')
         self.assertEqual(len(files), FILE_FEED_COUNT, files)
 
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -181,7 +181,6 @@ class PackageManagerModuleListTestCase(unittest.TestCase):
         sync_repo(cfg, repo)
         publish_repo(cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
-        sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
             baseurl=urljoin(cfg.get_base_url(), urljoin(
@@ -192,10 +191,10 @@ class PackageManagerModuleListTestCase(unittest.TestCase):
             repositoryid=repo['id']
         )
         cli_client = cli.Client(cfg)
-        self.addCleanup(cli_client.run, sudo + ('rm', repo_path))
+        self.addCleanup(cli_client.run, ('rm', repo_path), sudo=True)
         lines = cli_client.run((
-            sudo + ('dnf', 'module', 'list', '--all')
-        )).stdout.splitlines()
+            ('dnf', 'module', 'list', '--all')
+        ), sudo=True).stdout.splitlines()
         for key, value in MODULE_FIXTURES_PACKAGES.items():
             with self.subTest(package=key):
                 module = [line for line in lines if key in line]

--- a/pulp_2_tests/tests/rpm/api_v2/test_republish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_republish.py
@@ -186,8 +186,7 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
 
         # Upload an RPM, publish the repo, and count metadata files twice.
         cli_client = cli.Client(self.cfg)
-        sudo = () if cli.is_root(self.cfg) else ('sudo',)
-        find_repodata_cmd = sudo + (
+        find_repodata_cmd = (
             'find',
             os.path.join(
                 '/var/lib/pulp/published/yum/master/yum_distributor/',
@@ -199,8 +198,9 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
         for rpm in rpms:
             upload_import_unit(self.cfg, rpm, {'unit_type_id': 'rpm'}, repo)
             publish_repo(self.cfg, repo)
-            repodata_path = cli_client.run(find_repodata_cmd).stdout.strip()
-            found.append(cli_client.run(sudo + (
+            repodata_path = cli_client.run(
+                find_repodata_cmd, sudo=True).stdout.strip()
+            found.append(cli_client.run((
                 'find', repodata_path, '-type', 'f'
-            )).stdout.splitlines())
+            ), sudo=True).stdout.splitlines())
         return found

--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -121,7 +121,6 @@ class PackageManagerConsumeRPMTestCase(unittest.TestCase):
         repo = client.get(repo['_href'], params={'details': True})
         sync_repo(cfg, repo)
         publish_repo(cfg, repo)
-        sudo = () if cli.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,
             baseurl=urljoin(cfg.get_base_url(), urljoin(
@@ -132,7 +131,7 @@ class PackageManagerConsumeRPMTestCase(unittest.TestCase):
             repositoryid=repo['id']
         )
         cli_client = cli.Client(cfg)
-        self.addCleanup(cli_client.run, sudo + ('rm', repo_path))
+        self.addCleanup(cli_client.run, ('rm', repo_path), sudo=True)
         rpm_name = 'Cobbler'
         pkg_mgr = cli.PackageManager(cfg)
         pkg_mgr.install(rpm_name)

--- a/pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py
@@ -50,6 +50,7 @@ class MissingWorkersTestCase(unittest.TestCase):
         if not selectors.bug_is_fixed(2835, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2835')
         sudo = '' if cli.is_root(self.cfg) else 'sudo'
+        # machine.session is used here to keep SSH session open
         cli.Client(self.cfg).machine.session().run(
             "{} bash -c 'echo PULP_CONCURRENCY=1 >> {}'"
             .format(sudo, _PULP_WORKERS_CFG)
@@ -84,9 +85,9 @@ class MissingWorkersTestCase(unittest.TestCase):
 
         Reset Pulp because :meth:`test_all` may break Pulp.
         """
-        sudo = () if cli.is_root(self.cfg) else ('sudo',)
         # Delete last line from file.
-        cli.Client(self.cfg).run(sudo + ('sed', '-i', '$d', _PULP_WORKERS_CFG))
+        cli.Client(self.cfg).run(
+            ('sed', '-i', '$d', _PULP_WORKERS_CFG), sudo=True)
         reset_pulp(self.cfg)
 
 

--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -222,7 +222,6 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
         client = cli.Client(cfg)
         pkg_mgr = cli.PackageManager(cfg)
-        sudo = () if cli.is_root(cfg) else ('sudo',)
 
         # Create the second repository.
         repo_id = self.create_repo(cfg)
@@ -241,7 +240,7 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
             name=repo_id,
             repositoryid=repo_id
         )
-        self.addCleanup(client.run, sudo + ('rm', repo_path))
+        self.addCleanup(client.run, ('rm', repo_path), sudo=True)
         pkg_mgr.install(rpm_name)
         self.addCleanup(pkg_mgr.uninstall, rpm_name)
         client.run(('rpm', '-q', rpm_name))

--- a/pulp_2_tests/tests/rpm/cli/test_sync.py
+++ b/pulp_2_tests/tests/rpm/cli/test_sync.py
@@ -127,10 +127,8 @@ class ForceSyncTestCase(_BaseTestCase):
         rpms = self._list_rpms(cfg)
         rpm = random.choice(rpms)
         cmd = []
-        if not cli.is_root(cfg):
-            cmd.append('sudo')
         cmd.extend(('rm', '-rf', rpm))
-        client.run(cmd)
+        client.run(cmd, sudo=True)
         with self.subTest(comment='verify the rpm has been removed'):
             self.assertEqual(len(self._list_rpms(cfg)), len(rpms) - 1, rpm)
 

--- a/pulp_2_tests/tests/rpm/utils.py
+++ b/pulp_2_tests/tests/rpm/utils.py
@@ -215,6 +215,7 @@ def gen_yum_config_file(cfg, repositoryid, baseurl, name, **kwargs):
         section.write('[{}]\n'.format(repositoryid))
         for key, value in kwargs.items():
             section.write('{}: {}\n'.format(key, value))
+        # machine.session is used here to keep SSH session open
         cli.Client(cfg).machine.session().run(
             'echo "{}" | {}tee {} > /dev/null'.format(
                 section.getvalue(),


### PR DESCRIPTION
Using the new `sudo=True` argument on calls to `cli.Client.run`

129 tests executed and passed.