### PR TITLE
Adding One default per Repo TestCase

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -133,6 +133,7 @@ MODULE_FIXTURES_PACKAGES = {'duck': 3, 'kangaroo': 2, 'walrus': 2}
 MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
     'name': 'walrus',
     'stream': '0.71',
+    'new_stream': '5.21',
     'rpm_count': 4,
     'total_available_units': 5,
 })


### PR DESCRIPTION
This commit takes care of the following scenario
issue://github.com/PulpQE/pulp-smash/issues/1122 (One default per repo
scenario).
As a part of this testcase, the following are tested

* syncing a rpm repo with modules.
* changing the content of the modules.yaml with same unit-keys.
* checking whether the content count remains same, since the unit-keys
aren't changed