### PR TITLE
Add a section about contributing to the documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+# Creating Pulp 2 issues
+
+1. Describe what you expected to happen.
+
+2. Describe what actually happened.
+
+3. Describe what version of Pulp 2 and what OS is affected by the issue.
+
+4. State steps to re-create the issue.
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
-autodoc_default_flags = ['members']
-
+autodoc_default_options = {'members': None, 'undoc-members': None}
+autoclass_content = 'both'
 
 # Format-Specific Options -----------------------------------------------------
 htmlhelp_basename = 'Pulp2Testsdoc'

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,20 @@
+Contributing
+============
+
+Location: :doc:`/index` → :doc:`/contributing`
+
+Added a new test? Ready to submit a PR? Run ``make all``. Assure that your
+changes are according to the `Code Standards`_.
+
+Code Standards
+~~~~~~~~~~~~~~
+The same `code standards`_ adopted by Pulp Smash is adopted by Pulp 2 tests.
+This helps to create consistency among the projects.
+
+Review Process
+~~~~~~~~~~~~~~
+The same `review process`_ adopted by Pulp Smash is adopted by Pulp 2 tests.
+
+
+.. _code standards: https://pulp-smash.readthedocs.io/en/latest/about.html#code-standards
+.. _review process: https://pulp-smash.readthedocs.io/en/latest/about.html#review-process

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,5 +24,6 @@ Pulp 2 Tests makes heavy use of `Pulp Smash`_.
 
    installation
    configuration
+   contributing
    usage
    tests


### PR DESCRIPTION
Expand the documentation adding a section in how to contritube.

Add an ISSUE_TEMPLATE.

Update Sphinx `conf.py`. To reflect the new changes of `autodoc_default_flags`
that was deprecated on Sphinx 1.8. Update to use `autodoc_default_options`.