### PR TITLE
Fixing the issue in `test_remove_modulemd` test.

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -179,9 +179,11 @@ class ManageModularContentTestCase(unittest.TestCase):
             repo['content_unit_counts']['modulemd'],
             repo_initial['content_unit_counts']['modulemd'] - 1,
             repo['content_unit_counts'])
+        # after removing a module 'X', the number of rpms in the repo should
+        # decrease by the number of rpms present in 'X'.
         self.assertEqual(
             repo['content_unit_counts']['rpm'],
-            repo_initial['content_unit_counts']['modulemd'] -
+            repo_initial['content_unit_counts']['rpm'] -
             MODULE_FIXTURES_PACKAGE_STREAM['rpm_count'],
             repo['content_unit_counts'])
         self.assertIsNotNone(


### PR DESCRIPTION
The current `test_remove_modulemd` removes the module and has to test
whether all the rpms associated with the modulemd gets removed.Thus the
test has to check whether the final rpm count is initial rpm count minus
the number of rpms associated with the module that got removed.