### PR TITLE
Adding logic for removing modulemd_defaults

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -197,9 +197,9 @@ class ManageModularContentTestCase(unittest.TestCase):
             'type_ids': ['modulemd_defaults'],
         }
         repo = self.remove_module_from_repo(repo_initial, criteria)
-        self.assertEqual(
-            repo['content_unit_counts']['modulemd_defaults'],
-            0,
+        self.assertNotIn(
+            'modulemd_defaults',
+            repo['content_unit_counts'],
             repo['content_unit_counts'])
 
         self.assertEqual(


### PR DESCRIPTION
The current `test_remove_modulemd_defaults` test case removes modulemd_defaults and checks whether the count of modulemd_defaults is 0. However this field got removed from the repo and thus the test is made to check whether the field is a member of the repo.