### PR TITLE
Fix number of RPMs remove for test_remove_modulemd

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -183,8 +183,7 @@ class ManageModularContentTestCase(unittest.TestCase):
         # decrease by the number of rpms present in 'X'.
         self.assertEqual(
             repo['content_unit_counts']['rpm'],
-            repo_initial['content_unit_counts']['rpm'] -
-            MODULE_FIXTURES_PACKAGE_STREAM['rpm_count'],
+            repo_initial['content_unit_counts']['rpm'] - 1,
             repo['content_unit_counts'])
         self.assertIsNotNone(
             repo['last_unit_removed'],


### PR DESCRIPTION
Fix the number of RPMS that are removed after a modulemd is removed.

See: https://pulp.plan.io/issues/3985