### PR TITLE
Fix puppet/test_sync_publish module download version

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -205,19 +205,24 @@ response to a certain HTTP GET request. However:
 PUPPET_FEED_2 = 'https://forge.puppet.com'
 """The URL to a repository of Puppet modules."""
 
-PUPPET_MODULE_2 = {'author': 'puppetlabs', 'name': 'motd', 'version': '1.9.0'}
+PUPPET_MODULE_2 = {'author': 'puppetlabs', 'name': 'motd'}
 """Information about a Puppet module available at :data:`PUPPET_FEED_2`."""
 
-PUPPET_MODULE_URL_2 = ('{}/v3/files/{}-{}-{}.tar.gz'.format(
+PUPPET_MODULE_URL_2 = ('{}/v3/files/{}-{}-%s.tar.gz'.format(
     PUPPET_FEED_2,
     PUPPET_MODULE_2['author'],
     PUPPET_MODULE_2['name'],
-    PUPPET_MODULE_2['version'],
 ))
-"""The URL to a Puppet module available at :data:`PUPPET_FEED_2`."""
+"""The URL to a Puppet module available at :data:`PUPPET_FEED_2`.
+
+A version string should be provided to `-%s.tar.gz` e.g::
+
+    PUPPET_MODULE_URL_2 % '2.0.0'
+
+"""
 
 PUPPET_QUERY_2 = quote_plus('-'.join(
-    PUPPET_MODULE_2[key] for key in ('author', 'name', 'version')
+    PUPPET_MODULE_2[key] for key in ('author', 'name')
 ))
 """A query that can be used to search for Puppet modules.
 

--- a/pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py
@@ -127,15 +127,20 @@ class SyncValidFeedTestCase(BaseAPITestCase):
         )
         self.assertEqual(len(response['results']), 1)
 
-        # Download the Puppet module.
-        module = utils.http_get(PUPPET_MODULE_URL_2)
+        # Download the Puppet module directly from feed url.
+        latest_version = response['results'][0]['metadata']['version']
+        module_file = utils.http_get(PUPPET_MODULE_URL_2 % latest_version)
+
         client.response_handler = api.safe_handler
-        response = client.get(response['results'][0]['file_uri'])
+        # Download the Puppet module stored by Pulp.
+        file_response = client.get(response['results'][0]['file_uri'])
+
+        # Assert the files are the same.
         with self.subTest():
-            self.assertEqual(module, response.content)
+            self.assertEqual(module_file, file_response.content)
         with self.subTest():
             self.assertIn(
-                response.headers['content-type'],
+                file_response.headers['content-type'],
                 ('application/gzip', 'application/x-gzip')
             )
 


### PR DESCRIPTION
As described in https://github.com/PulpQE/Pulp-2-Tests/blob/master/pulp_2_tests/constants.py#L222-L242

> it is impossible to create a Puppet repository and sync only an exact module or set of modules.

So instead of setting specific version the test will now take the latest available version.

<details>

```python
$ py.test -vv -s pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py -k test_matching_query
======================================== test session starts =========================================
platform linux -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /home/rochacbruno/Projects/pulp/venv/bin/python3.6
cachedir: .pytest_cache
metadata: {'Python': '3.6.6', 'Platform': 'Linux-4.18.5-200.fc28.x86_64-x86_64-with-fedora-28-Twenty_Eight', 'Packages': {'pytest': '3.7.4', 'py': '1.6.0', 'pluggy': '0.7.1'}, 'Plugins': {'metadata': '1.7.0', 'html': '1.19.0', 'cov': '2.6.0'}}
rootdir: /home/rochacbruno/Projects/pulp/Pulp-2-Tests, inifile:
plugins: metadata-1.7.0, html-1.19.0, cov-2.6.0
collected 24 items / 23 deselected                                                                   

pulp_2_tests/tests/puppet/api_v2/test_sync_publish.py::SyncValidFeedTestCase::test_matching_query PASSED

============================== 1 passed, 23 deselected in 51.57 seconds ==============================

```

</details>