### PR TITLE
Adding testcase for validating the collections in updateinfo

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
@@ -46,6 +46,99 @@ class ManageModularErrataTestCase(unittest.TestCase):
         4. Get the ``updateinfo`` from the repodata of the published repo.
         5. Compare this against the ``update_info.xml`` in the fixtures repo.
         """
+        _, update_list = self._set_repo_and_get_repo_data()
+
+        # getting the update info from the fixtures repo
+        update_info_fixtures = get_xml_content_from_fixture(
+            fixture_path=RPM_WITH_MODULES_FEED_URL,
+            data_type='updateinfo',
+        )
+        self.assertEqual(
+            self._get_errata_rpm_mapping(update_list),
+            self._get_errata_rpm_mapping(update_info_fixtures),
+            'mismatch in the module packages.'
+        )
+
+    def test_collection_field(self):
+        """Test the collection field in the update info.
+
+        This test provides the following
+
+        1. Check whether all the modules in the published repo
+            contains a collection field.
+        2. Check whether the collection field has proper name. The collection name computation
+            is as below.
+
+        The collection name is created using the information from fixtures that is stored in
+        a set {<errata-id>:<module-name>}. First, the set information is used in computing
+        a set ``collections_from_fixtures`` that maps the repo_id to the collection-name.
+        The collection-name set is computed using the logic <repo-id>_<index>_<module-name>.
+        The module name is ``default`` and the index is``0`` for ursine RPMs. The set is
+        created using set-comprehension and x-path. After creating the set,
+        it appears as in the example below.
+
+        example :
+        collections_from_fixtures = {
+            'RHEA..1' : 'repo_id_1_duck',
+            'RHEA..2' : 'repo_id_2_duck',
+            'RHEA..3' : 'repo_id_0_default'
+        }
+
+        This set is compared against the collection-name from the published repo's ``updateinfo``.
+        """
+        repo, update_list = self._set_repo_and_get_repo_data()
+
+        # getting the update info from the fixtures repo
+        update_info_fixtures = get_xml_content_from_fixture(
+            fixture_path=RPM_WITH_MODULES_FEED_URL,
+            data_type='updateinfo',
+        )
+
+        # Errata ID to Collection name map in Updateinfo of published repo.
+        collection_update_list = {
+            update.find('./id').text: update.find('.//collection').attrib['short']
+            for update in update_list.findall('update')
+        }
+
+        collections_from_fixtures = {
+            update.find('id').text:
+            'default' if update.find('.//module') is None
+            else update.find('.//module').attrib['name']
+            for update in
+            update_info_fixtures.findall('.//update')
+        }
+
+        # ``indexes`` is used to increase the index of the module in the collections
+        indexes = {}
+        for key, val in collections_from_fixtures.items():
+            if val in indexes:
+                indexes[val] += 1
+            else:
+                indexes[val] = 1
+            collections_from_fixtures[key] = (
+                '{}_0_default'.format(repo['id'])
+                if val == 'default'
+                else '{}_{}_{}'.format(repo['id'], indexes[val], val)
+            )
+
+        self.assertEqual(
+            collections_from_fixtures,
+            collection_update_list,
+            'collection names not proper'
+        )
+
+    def _set_repo_and_get_repo_data(self):
+        """Create and Publish the required repo for this class.
+
+        This method does the following:
+
+        1. Create, Sync and Publish a repo with
+            ``RPM_WITH_MODULES_FEED_URL``
+        2. Get ``updateinfo`` xml of the published repo.
+
+        :returns: A tuple containing the repo that is created, along with
+            the ``updateinfo`` xml of the created repo.
+        """
         body = gen_repo(
             importer_config={'feed': RPM_WITH_MODULES_FEED_URL},
             distributors=[gen_distributor(auto_publish=True)]
@@ -56,20 +149,9 @@ class ManageModularErrataTestCase(unittest.TestCase):
 
         # getting the update info from the published repo
         repo = self.client.get(repo['_href'], params={'details': True})
-        update_list = get_repodata(
+        return repo, get_repodata(
             self.cfg,
             repo['distributors'][0], 'updateinfo'
-        )
-
-        # getting the update info from the fixtures repo
-        update_info_file = get_xml_content_from_fixture(
-            fixture_path=RPM_WITH_MODULES_FEED_URL,
-            data_type='updateinfo',
-        )
-        self.assertEqual(
-            self._get_errata_rpm_mapping(update_list),
-            self._get_errata_rpm_mapping(update_info_file),
-            'mismatch in the module packages.'
         )
 
     @staticmethod


### PR DESCRIPTION
This testcase tests whether the collections field has the proper value
in the updateinfo of the published repo. The collections field is
according to the following
* In case of modules, the collections field should have the `name` as
<repo_id>_<index>_<module_name> where the index starts from 1 and
increments for modules with same name
* For non module files, the collection `name` field is
<repo_id>_0_default

Refer the following:
issue #94
[pulp.plan #4024](https://pulp.plan.io/issues/4024)