### PR TITLE
Test issue 94 copy errata

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -130,6 +130,13 @@ MODULE_FIXTURES_PACKAGES = {'duck': 3, 'kangaroo': 2, 'walrus': 2}
 .. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
 """
 
+MODULE_FIXTURES_ERRATA = MappingProxyType({
+    'errata_id': 'RHEA-2012:0059',
+    'rpm_count': 2,
+    'total_available_units': 3,
+})
+"""The errata information containing the modular rpm data."""
+
 MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
     'name': 'walrus',
     'stream': '0.71',

--- a/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
@@ -46,6 +46,89 @@ class ManageModularErrataTestCase(unittest.TestCase):
         4. Get the ``updateinfo`` from the repodata of the published repo.
         5. Compare this against the ``update_info.xml`` in the fixtures repo.
         """
+        _, update_list = self._set_repo_and_get_repo_data()
+
+        # getting the update info from the fixtures repo
+        update_info_fixtures = get_xml_content_from_fixture(
+            fixture_path=RPM_WITH_MODULES_FEED_URL,
+            data_type='updateinfo',
+        )
+        self.assertEqual(
+            self._get_errata_rpm_mapping(update_list),
+            self._get_errata_rpm_mapping(update_info_fixtures),
+            'mismatch in the module packages.'
+        )
+
+    def test_collection_field(self):
+        """Test the collection field in the update info.
+
+        This test provides the following
+
+        1. Check whether all the modules in the published repo
+           contains a collection field
+        2. Check whether the collection field is unique
+        """
+        repo, update_list = self._set_repo_and_get_repo_data()
+
+        # getting the update info from the fixtures repo
+        update_info_fixtures = get_xml_content_from_fixture(
+            fixture_path=RPM_WITH_MODULES_FEED_URL,
+            data_type='updateinfo',
+        )
+
+        # collections from published repo
+        collection_update_list = {
+            update.find('./id').text: update.find('.//collection').attrib['short']
+            for update in update_list.findall('update')
+        }
+
+        # collections from fixtures
+        # the below dict comprehension computes the following
+        # It gets the collection elements from the fixtures `updateinfo`,
+        # gets the module names from each collection and maps it to update ID.
+        # If module name doesn't exist, it replaces it as default
+        # else module name is stored.
+        # example : collections_from_fixtures = {
+        #                                        'RHEA..1' : 'duck',
+        #                                        'RHEA..2' : 'default'
+        #                                       }
+        collections_from_fixtures = {
+            update.find('id').text:
+            'default' if update.find('.//module') is None
+            else update.find('.//module').attrib['name']
+            for update in
+            update_info_fixtures.findall('.//update')
+        }
+        # Adding repo_id, indexes and module_name for the collection
+        # example : collections_from_fixtures = {
+        #                                        'RHEA..1' : 'repo_id_1_duck',
+        #                                        'RHEA..2' : 'repo_id_2_duck'
+        #                                       }
+        indexes = {}
+        for key in collections_from_fixtures:
+            val = collections_from_fixtures[key]
+            if val in indexes:
+                indexes[val] += 1
+            else:
+                indexes[val] = 1
+            collections_from_fixtures[key] = '{}_0_default'.format(repo['id']) \
+                if val == 'default' \
+                else '{}_{}_{}'.format(repo['id'], indexes[val], val)
+
+        self.assertEqual(
+            collections_from_fixtures,
+            collection_update_list,
+            'collection names not proper'
+        )
+
+    def _set_repo_and_get_repo_data(self):
+        """Create and Publish the required repo for this class.
+
+        This method does the following:
+        1. Create, Sync and Publish a repo with
+            ``RPM_WITH_MODULES_FEED_URL``
+        2. get ``updateinfo`` xml of the published repo.
+        """
         body = gen_repo(
             importer_config={'feed': RPM_WITH_MODULES_FEED_URL},
             distributors=[gen_distributor(auto_publish=True)]
@@ -56,20 +139,9 @@ class ManageModularErrataTestCase(unittest.TestCase):
 
         # getting the update info from the published repo
         repo = self.client.get(repo['_href'], params={'details': True})
-        update_list = get_repodata(
+        return repo, get_repodata(
             self.cfg,
             repo['distributors'][0], 'updateinfo'
-        )
-
-        # getting the update info from the fixtures repo
-        update_info_file = get_xml_content_from_fixture(
-            fixture_path=RPM_WITH_MODULES_FEED_URL,
-            data_type='updateinfo',
-        )
-        self.assertEqual(
-            self._get_errata_rpm_mapping(update_list),
-            self._get_errata_rpm_mapping(update_info_file),
-            'mismatch in the module packages.'
         )
 
     @staticmethod


### PR DESCRIPTION
 The `test_copy_errata` method is added to the `test_modular_errata` class.
 This method does the following
   * Creates,syncs and publishes a repo with feed: `RPM_WITH_MODULES_FEED_URL`
   * Copies the repo into another repo, such that only RHEA-2012:0059 is copied
   * Check whether the modules along with the rpms are copied to the destination repository
