### PR TITLE
Pin sphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
-autodoc_default_options = {'members': None, 'undoc-members': None}
+autodoc_default_flags = ['members']
 
 # Format-Specific Options -----------------------------------------------------
 htmlhelp_basename = 'Pulp2Testsdoc'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             'pydocstyle',
             'pylint',
             # For `make docs-html` and `make docs-clean`
-            'sphinx',
+            'sphinx<1.8',
             # For `make package`
             'wheel',
             # For `make publish`


### PR DESCRIPTION
Pin sphinx version < 1.8. Since the update to the latest version we have been
facing issues generating the docs.

Pin to an old, but stable version.