### PR TITLE
Fix docs autodoc flags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
-autodoc_default_options = {'members': None, 'undoc-members': None}
+nitpick_ignore = [('py:class', 'type')]
+autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
 
 # Format-Specific Options -----------------------------------------------------
 htmlhelp_basename = 'Pulp2Testsdoc'


### PR DESCRIPTION
conf.py was settingautodoc_default_options but the propoer variable is
autodoc_default_flags.

http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_flags