### PR TITLE
Skip tests that require Pulp 2.18

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
@@ -41,8 +41,8 @@ class ManageModularErrataTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class wide variables."""
         cls.cfg = config.get_config()
-        if cls.cfg.pulp_version < Version('2.17'):
-            raise unittest.SkipTest('This test requires Pulp 2.17 or newer.')
+        if cls.cfg.pulp_version < Version('2.18'):
+            raise unittest.SkipTest('This test requires Pulp 2.18 or newer.')
         cls.client = api.Client(cls.cfg, api.json_handler)
 
     def test_sync_publish_update_info(self):


### PR DESCRIPTION
As per issue https://pulp.plan.io/issues/3919 features related to modular
Errata content will land on Pulp 2.18. Skip those tests otherwise.

See: #94