### PR TITLE
Uploading RPM with large metadata and testing no exceptions raised

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -643,3 +643,13 @@ SRPM_UNSIGNED_URL = urljoin(SRPM_UNSIGNED_FEED_URL, SRPM)
 
 Built from :data:`SRPM_UNSIGNED_FEED_URL` and :data:`SRPM`.
 """
+
+PULP_LARGE_RPM_REPO = 'https://repos.fedorapeople.org/pulp/pulp/rpm_large_metadata/'
+"""A URL which serves the large rpm files for Pulp."""
+
+RPM_LARGE_METADATA = 'nodejs-babel-preset-es2015-6.6.0-2.el6.noarch.rpm'
+"""RPM with filelists size more than 9MB and less than 15 MB."""
+
+RPM_LARGE_METADATA_FEED = urljoin(PULP_LARGE_RPM_REPO,
+                                  RPM_LARGE_METADATA)
+"""Feed URL for ``RPM_LARGE_METADATA``."""

--- a/pulp_2_tests/tests/rpm/api_v2/utils.py
+++ b/pulp_2_tests/tests/rpm/api_v2/utils.py
@@ -495,3 +495,14 @@ def get_rpm_names_versions(cfg, repo):
     for versions in names_versions.values():
         versions.sort(key=Version)
     return names_versions
+
+
+def get_rpm_published_path(cfg, repo, rpm_name):
+    """Return the absolute path to ``pulp_2_tests.constants.RPM``."""
+    _path = '/var/lib/pulp/published/yum/https/repos/{}'.format(
+        repo['distributors'][0]['config']['relative_url']
+    )
+    return cli.Client(cfg).run(
+        'find {} -name'.format(_path)
+        .split() + [rpm_name]
+    ).stdout.strip()


### PR DESCRIPTION
This commit verifies whether an rpm file
``constants.RPM_LARGE_METADATA`` can be uploaded into an rpm repo in
pulp without any DocumentTooLarge error raised.

refer [#723](https://pulp.plan.io/issues/723)_
Closes #88