### PR TITLE
Adding sync test case for RPM packages with sha512 checksum

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -571,6 +571,9 @@ RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM)
 Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM`.
 """
 
+RPM_SHA_512_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-with-sha-512/')
+"""The URL to an RPM repository with sha512 checksum."""
+
 RPM_UPDATED_INFO_FEED_URL = urljoin(
     PULP_FIXTURES_BASE_URL,
     'rpm-updated-updateinfo/'


### PR DESCRIPTION
This commit adds a testcase for syncing a rpm packages feed that is
having checksum as sha512. This testcase syncs rpms from the feed
`RPM_SHA_512_FEED_URL`.

refer [pulp plan 4007](https://pulp.plan.io/issues/4007)
closes https://pulp.plan.io/issues/4124.