### PR TITLE
Updating the applicability schema to include modulemd

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_content_applicability.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_content_applicability.py
@@ -70,6 +70,10 @@ CONTENT_APPLICABILITY_REPORT_SCHEMA = {
                         'type': 'array',
                         'items': {'type': 'string'}
                     },
+                    'modulemd': {
+                        'type': 'array',
+                        'items': {'type': 'string'}
+                    },
                     'rpm': {
                         'type': 'array',
                         'items': {'type': 'string'}
@@ -83,7 +87,12 @@ CONTENT_APPLICABILITY_REPORT_SCHEMA = {
         }
     }
 }
-"""A schema for a content applicability report for a consumer."""
+"""A schema for a content applicability report for a consumer.
+
+Schema now includes modulemd profiles:
+
+* `Pulp #3925 <https://pulp.plan.io/issues/3925>`_
+"""
 
 
 class BasicTestCase(unittest.TestCase):
@@ -181,6 +190,12 @@ class BasicTestCase(unittest.TestCase):
                 len(applicability[0]['applicability']['erratum']),
                 1,
                 applicability[0]['applicability']['erratum'],
+            )
+        with self.subTest(comment='verify modulemd listed in report'):
+            self.assertEqual(
+                len(applicability[0]['applicability']['modulemd']),
+                0,
+                applicability[0]['applicability']['modulemd'],
             )
         with self.subTest(comment='verify RPMs listed in report'):
             self.assertEqual(


### PR DESCRIPTION
Commit Message:

Adding and verifying that the modulemd content type under applicability.
* Updated CONTENT_APPLICABILITY_REPORT_SCHEMA
* Updated the fetch to validates modulemd value which is currently empty
* Verified test_negative method has no dependent return validation on current modulemd data

Refer #3925
Closes #4156

Redmine:
- https://pulp.plan.io/issues/4156

Pulp Version:
- 2.19a1

Platforms Tested:
- RHEL7.6

Linting and Doc Tests:
- make all