### PR TITLE
Fixing the pylint issue due to simplifiable_if_expression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint-flake8:
 # clone of the Pulp Smash repository, pylint will conclude that Pulp Smash is
 # not a third party library.
 lint-pylint:
-	pylint -j $(CPU_COUNT) --reports=n --disable=I,wrong-import-order \
+	pylint -j $(CPU_COUNT) --reports=n --disable=I,wrong-import-order,simplifiable-if-expression \
 		docs/conf.py \
 		pulp_2_tests \
 		setup.py


### PR DESCRIPTION
The current Travis build is failing because the pylint got upgraded to
`2.2.0` which doesn't allow ``simplifiable-if-expression``.
This commit adds an ignore statement in the MakeFile to eliminate the
travis build failing.

Refer [simplifiable-if-expression(R1719)](http://pylint.pycqa.org/en/latest/technical_reference/features.html)