### PR TITLE
Adding logic for treating modules as gz

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 """Tests that perform actions over RPM modular repositories."""
+import gzip
+import io
 import unittest
 from urllib.parse import urljoin
 from xml.etree import ElementTree
@@ -361,6 +363,9 @@ class UploadModuleTestCase(unittest.TestCase):
         xpath = '{{{}}}location'.format(RPM_NAMESPACES['metadata/repo'])
         relative_path = data_elements[0].find(xpath).get('href')
         unit = utils.http_get(urljoin(path, relative_path))
+        with io.BytesIO(unit) as compressed:
+            with gzip.GzipFile(fileobj=compressed) as decompressed:
+                unit = decompressed.read()
         return unit
 
 


### PR DESCRIPTION
The current jenkins master jobs are failing since, the `module.yaml.gz`
file are acting as gz archived files. This means the testcases that
depends on downloading the module file and uploading the module, needs
the modules file to be gunzipped before uploading. Thus adding logic for
gunzipping module.yaml.gz file before uploading it for the testcases.

The following testcases are affected
* rpm.api_v2.test_modularity.UploadModuleTestCase.test_upload_module
* rpm.api_v2.test_modularity.UploadModuleTestCase.test_one_default_per_repo