### PR TITLE
Adding checks for non-modular files non containing modules.yaml

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -641,6 +641,9 @@ Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM2`.
 RPM_WITH_MODULES_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-with-modules/')
 """The URL to a modular RPM repository."""
 
+RPM_WITH_MODULES_SHA1_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-with-sha-1-modular/')
+"""The URL to a modular RPM repository with SHA1 checksum."""
+
 RPM_WITH_PULP_DISTRIBUTION_FEED_URL = urljoin(
     PULP_FIXTURES_BASE_URL, 'rpm-with-pulp-distribution/')
 """The URL to a RPM repository with a PULP_DISTRIBUTION.xml file."""


### PR DESCRIPTION
This commit syncs content and publishes a modular repo which is SHA1
checksummed. This uses the fixture
`https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-with-sha-1-modular/`
which is built in the PR Pulp-Fixtures/115.

For testing this independently, please use the fixtures url
`https://repos.fedorapeople.org/pulp/pulp/demo_repos/sha1-raga/rpm-with-sha-1-modular/`
within `pulp_2_tests/constants.py`

Closes #4351