### PR TITLE
Add test for recursive_conservative copy

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -669,6 +669,12 @@ RPM_WITH_VENDOR_URL = urljoin(
 )
 """The URL of an RPM with a specified vendor in its header."""
 
+RPM_WITH_OLD_VERSION_URL = urljoin(
+    RPM_UNSIGNED_FEED_URL,
+    'walrus-0.71-1.noarch.rpm'
+)
+"""walrus RPM package has 2 versions. The URL to the older version."""
+
 SRPM_RICH_WEAK_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-richnweak-deps/')
 """The URL to an SRPM repository with weak and rich dependencies."""
 


### PR DESCRIPTION
Add test for recursive_conservative copy. Explore the newly added flag
`recursive_conservative` used together with `recursive`.

See: https://pulp.plan.io/issues/4269