### PR TITLE
Remove support to module data on RepoMDTestCase

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_repomd.py
@@ -7,7 +7,6 @@ import os
 import unittest
 from urllib.parse import urljoin
 
-from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
@@ -79,9 +78,6 @@ class RepoMDTestCase(unittest.TestCase):
             'primary',
             'updateinfo',
         }
-        # Pulp 2.17 adds support for modularity.
-        if self.cfg.pulp_version >= Version('2.17'):
-            expected_data_types.add('modules')
         self.assertEqual(data_types, expected_data_types, data_types)
 
 


### PR DESCRIPTION
Commit 65c4ccf56f2ba1f6ab245546fdb92082a50e5ad3 introduced support to
modularity on RepoMDTestCase test case.
After further investigation with the dev team it was concluded that the
sane behaviour is to not have the `modules` data type returned as part
of the `repomd.xml` this is valid for the versions after 2.18.1. Thus
updating the test to reflect this change.

Related commits:

https://github.com/PulpQE/Pulp-2-Tests/commit/235197e9f3e75d8824819f653f5de1ee3df12b3e
https://github.com/PulpQE/Pulp-2-Tests/pull/11/files