### PR TITLE
Drop Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: python
 python:
-- 3.4
-- 3.5
 - 3.6
 env:
 - PULP_SMASH_NAME=pulp-smash

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ setup(
         'Intended Audience :: Developers',
         ('License :: OSI Approved :: GNU General Public License v3 or later '
          '(GPLv3+)'),
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],


### PR DESCRIPTION
Drop support for Python 3.4 and 3.5. Python 3.6 is available in RHEL7
family using software collections.

Reduce the matrix of supported Python versions.