### PR TITLE
Add login before read content SearchContentTestCase

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -8,6 +8,7 @@ from pulp_smash import api, cli, config, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import (
     publish_repo,
+    pulp_admin_login,
     search_units,
     sync_repo,
     upload_import_unit,
@@ -159,6 +160,7 @@ class SearchContentTestCase(unittest.TestCase):
         cfg = config.get_config()
         if cfg.pulp_version < Version('2.17.1'):
             raise unittest.SkipTest('This test requires Pulp 2.17.1 or newer.')
+        pulp_admin_login(cfg)
         api_client = api.Client(cfg, api.json_handler)
         body = gen_repo(
             importer_config={'feed': RPM_RICH_WEAK_FEED_URL},


### PR DESCRIPTION
Run pulp_admin_login before read content on search test, that
will ensure the login certificates are in place and the content can
be read.