### PR TITLE
Skipping modular tests due to #4405 libsolve segfault

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modular_errata.py
@@ -25,6 +25,7 @@ from pulp_2_tests.tests.rpm.api_v2.utils import (
     get_repodata,
     get_xml_content_from_fixture,
 )
+from pulp_2_tests.tests.rpm.utils import check_issue_4405
 
 
 class ManageModularErrataTestCase(unittest.TestCase):
@@ -43,6 +44,8 @@ class ManageModularErrataTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         if cls.cfg.pulp_version < Version('2.18'):
             raise unittest.SkipTest('This test requires Pulp 2.18 or newer.')
+        if check_issue_4405(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/4405')
         cls.client = api.Client(cls.cfg, api.json_handler)
 
     def test_sync_publish_update_info(self):

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -32,10 +32,21 @@ from pulp_2_tests.tests.rpm.api_v2.utils import (
     get_repodata_repomd_xml,
 )
 from pulp_2_tests.tests.rpm.utils import (
+    check_issue_4405,
     gen_yum_config_file,
     os_support_modularity,
 )
-from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_2_tests.tests.rpm.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Possibly skip the tests in this module.
+
+    Skip tests if `Pulp #4405 <https://pulp.plan.io/issues/4405>`_ affects us.
+    """
+    set_up_module()
+    if check_issue_4405(config.get_config()):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/4405')
 
 
 class ManageModularContentTestCase(unittest.TestCase):

--- a/pulp_2_tests/tests/rpm/utils.py
+++ b/pulp_2_tests/tests/rpm/utils.py
@@ -127,6 +127,17 @@ def check_issue_3876(cfg):
             not selectors.bug_is_fixed(3876, cfg.pulp_version))
 
 
+def check_issue_4405(cfg):
+    """Return true if `Pulp #4405`_ affects the targeted Pulp system.
+
+    :param cfg: The Pulp system under test.
+
+    .. _Pulp #4405: https://pulp.plan.io/issues/4405
+    """
+    return (cfg.pulp_version >= Version('2.19') and
+            not selectors.bug_is_fixed(4405, cfg.pulp_version))
+
+
 def os_is_f26(cfg, pulp_host=None):
     """Tell whether the given Pulp host's OS is F26."""
     return (utils.get_os_release_id(cfg, pulp_host) == 'fedora' and


### PR DESCRIPTION
Issue #4405 is a regression due to libsolv in RHEL releases affecting all modular tests and hanging Jenkins CI.

Skipping tests until the issue is resolved.

refs #4405