### PR TITLE
Adding SRPM CLI test for --force-full with --srpm skip

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -684,6 +684,9 @@ RPM_WITH_OLD_VERSION_URL = urljoin(
 )
 """walrus RPM package has 2 versions. The URL to the older version."""
 
+SRPM_DUPLICATE_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-duplicate/')
+"""The URL to an SRPM repository with duplicate RPMs in repodata."""
+
 SRPM_RICH_WEAK_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-richnweak-deps/')
 """The URL to an SRPM repository with weak and rich dependencies."""
 


### PR DESCRIPTION
Issue #4397 addressed an issue where duplicate SRPMS would fail on sync when using `--srpm skip`.

Adding CLI test to ensure that in this scenario, the SRPMS are skipped, the following resulting sync would pass without issue.

Related to pulp-fixtures #119.

refs #4397
closes #4459