### PR TITLE
Updating MODULE_FIXTURES_ERRATA to account for --recursive copy

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -141,7 +141,7 @@ MODULE_FIXTURES_PACKAGES = {'duck': 3, 'kangaroo': 2, 'walrus': 2}
 MODULE_FIXTURES_ERRATA = MappingProxyType({
     'errata_id': 'RHEA-2012:0059',
     'rpm_count': 2,
-    'total_available_units': 3,
+    'total_available_units': 5,
 })
 """The errata information containing the modular rpm data."""
 


### PR DESCRIPTION
Updates to the definition of `--recursive` and `--recursive_conservative` are now defined in documentation with PR #1289 and Redmine Story #4371

The amount of units copied on a `--recursive` eratta copy is now updated
to reflect that change.

refs #4371