### PR TITLE
Modify documentation about installation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,6 @@ Pulp 2 Tests is a collection of functional tests for `Pulp`_ 2.
 Pulp 2 Tests has a presence on the following websites:
 
 * `Documentation`_ is available on ReadTheDocs.
-* A `Python package`_ is available on PyPi.
 * `Source code`_ and the issue tracker are available on GitHub.
 
 Pulp 2 Tests makes heavy use of `Pulp Smash`_.
@@ -14,7 +13,6 @@ Pulp 2 Tests makes heavy use of `Pulp Smash`_.
 .. _Documentation: https://pulp-2-tests.readthedocs.io
 .. _Pulp Smash: https://pulp-smash.readthedocs.io/
 .. _Pulp: https://pulpproject.org
-.. _Python package: https://pypi.python.org/pypi/pulp-2-tests
 .. _Source code: https://github.com/PulpQE/pulp-2-tests/
 
 .. Everything above this comment should also be in the README, word for word.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,9 +13,10 @@ virtualenv:
     python3 -m venv ~/.venvs/pulp-2-tests
     source ~/.venvs/pulp-2-tests/bin/activate
     pip install --upgrade pip
-    pip install pulp-2-tests
+    pip install git+https://github.com/PulpQE/Pulp-2-Tests.git#egg=pulp-2-tests
     pulp-smash settings create  # declare information about Pulp
-    python3 -m unittest discover pulp_2_tests.tests  # run the tests
+    # Run the tests using unittest or use the test runner of your preference.
+    python3 -m unittest discover pulp_2_tests.tests 
 
 For an explanation of key concepts and more installation strategies, see
 `Installing Python Modules`_. For an explanation of virtualenvs, see `Virtual


### PR DESCRIPTION
It was decide as a group to not push releases of Pulp2-Tests to PyPi.
Update the documentation to reflect this change.

Uses `pip install git` as the prefered way to install Pulp2-tests.