### PR TITLE
Updating CopyConservativeTestCase to include dependency copy test

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_copy.py
@@ -254,6 +254,7 @@ class CopyConservativeTestCase(unittest.TestCase):
 
     * `Pulp #4152 <https://pulp.plan.io/issues/4152>`_
     * `Pulp #4269 <https://pulp.plan.io/issues/4269>`_
+    * `Pulp #4371 <https://pulp.plan.io/issues/4371>`_
     """
 
     @classmethod
@@ -389,6 +390,37 @@ class CopyConservativeTestCase(unittest.TestCase):
             for unit in search_units(self.cfg, repo, {'type_ids': ['rpm']})
         ]
         self.assertEqual(len(dst_unit_ids), 1, dst_unit_ids)
+
+    def test_recursive_noconservative_dependency(self):
+        """Recursive, non-conservative, and ``walrus-0.71`` on B.
+
+        Do the following:
+
+        1. Copy ``chimpanzee`` RPM package from repository A to B using:
+           ``recursive`` as True, ``recursive_conservative`` as False, and an
+           older version of walrus package is present on the repo B before
+           the copy.
+        2. Assert that total number of RPM of units copied is equal to ``6``,
+           and the walrus package version is equal to both ``5.21`` and
+           ``0.71``.
+
+        Additional permutation added as ``--recursive`` should ensure
+        the ``latest`` version of the RPM is also copied.
+        """
+        repo = self.copy_units(True, False, True)
+        versions = [
+            unit['metadata']['version']
+            for unit in search_units(self.cfg, repo, {'type_ids': ['rpm']})
+            if unit['metadata']['name'] == 'walrus'
+        ]
+        self.assertEqual(len(versions), 2, versions)
+        self.assertEqual(versions[0], '5.21', versions)
+        self.assertEqual(versions[1], '0.71', versions)
+        dst_unit_ids = [
+            unit['metadata']['name']
+            for unit in search_units(self.cfg, repo, {'type_ids': ['rpm']})
+        ]
+        self.assertEqual(len(dst_unit_ids), 6, dst_unit_ids)
 
     def copy_units(self, recursive, recursive_conservative, old_dependency):
         """Copy units using ``recursive`` and  ``recursive_conservative``."""


### PR DESCRIPTION
Documentation added from #4543 highlighted that on ``--recursive``, the ``latest`` RPMs dependencies should be copied.

Adding a case where ``walrus-0.71`` is already on B and ``chimpanzee`` will copy the latest version of ``walrus`` to B.

Updating constant values appropriately.

See: https://pulp.plan.io/issues/4543

refs #4543