### PR TITLE
Updating CopyModulesTestCase to include latest dependency test

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -175,6 +175,7 @@ MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
     'new_stream': '5.21',
     'rpm_count': 4,
     'total_available_units': 5,
+    'module_defaults': 3,
 })
 """The name and the stream of the package listed in `modules.yaml`_.
 


### PR DESCRIPTION
## Problem

Documentation added from #4371 highlighted that on `--recursive` the latest RPM dependencies should be copied.

The creation of #4543 updates tests with the inclusion of logic from #4371.

## Changes
Adding cases where `walrus-0.71 RPM` is already on B.

Through multiple permutations of `module_defaults` and `modulemd` with `override_config`,
copying the walrus module will copy the correct streams of walrus module and dependent RPMs
from A to B.

## References
See:

- https://pulp.plan.io/issues/4371
- https://pulp.plan.io/issues/4543

closes #4364