### PR TITLE
Skip rich/weak copy test based on a certain Pulp version

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -223,6 +223,8 @@ class CopyRecursiveUnitsTestCase(unittest.TestCase):
 
         See :meth:`do_test`."
         """
+        if self.cfg.pulp_version < Version('2.18.1'):
+            raise unittest.SkipTest('This test requires Pulp 2.18.1 or newer.')
         repo = self.do_test(True, True)
         dst_unit_ids = [
             unit['metadata']['name'] for unit in


### PR DESCRIPTION
The `recursive_conservative` flag was added on Pulp 2.18.1, adjust a method
present on `CopyRecursiveUnitsTestCase` to just run if the Pulp version
is adequate.

See: https://pulp.plan.io/issues/4152
Also: https://docs.pulpproject.org/plugins/pulp_rpm/user-guide/release-notes/2.18.x.html#pulp-2-18-1