### PR TITLE
Updating CopyModulesTestCase to include latest dependency test

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -175,6 +175,7 @@ MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
     'new_stream': '5.21',
     'rpm_count': 4,
     'total_available_units': 5,
+    'module_defaults': 3,
 })
 """The name and the stream of the package listed in `modules.yaml`_.
 


### PR DESCRIPTION
## Problem

Documentation added from #4371 highlighted that on `--recursive` the latest RPM dependencies should be copied.

The creation of #4543 updates tests with the inclusion of logic from #4371.

## Changes
Adding cases where `walrus-0.71 RPM` is already on B.

Through multiple permutations of `module_defaults` and `modulemd` with `override_config`,
copying the walrus module will copy the correct streams of walrus module and dependent RPMs
from A to B.

## Notes

### Note 1
The completion of `recursive` and `recursive_conservative` `override_config` options was not completed until 2.19

As a result, both tests have has the `pulp_version` check reset to 2.19.

### Note 2
There is refactored duplication for `copy_units` in this and other test cases.

The issue Pulp-2 Issue #179 has been written to address this refactor at a later time and get this test into production now.

## References
See:

- https://pulp.plan.io/issues/4371
- https://pulp.plan.io/issues/4543

closes #4364