### PR TITLE
[updated] Adding tests for Modular content in search API

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -650,6 +650,9 @@ RPM2_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM2)
 Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM2`.
 """
 
+RPM_WITH_MODULES_FEED_COUNT = 3
+"""The number of modules available at :data:`RPM_WITH_MODULES_FEED_URL`."""
+
 RPM_WITH_MODULES_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-with-modules/')
 """The URL to a modular RPM repository."""
 


### PR DESCRIPTION
This commit takes care of testing the search api returns modular
content, and also checks whether the `updateinfo.xml` has erratas
present in them.

closes #4112
replaces #166 