### PR TITLE
Adjust parameter to fit function call bug_is_fixed 

### DIFF
--- a/pulp_2_tests/tests/puppet/cli/test_sync.py
+++ b/pulp_2_tests/tests/puppet/cli/test_sync.py
@@ -15,7 +15,7 @@ def setUpModule():  # pylint:disable=invalid-name
     See `Pulp #2574 <https://pulp.plan.io/issues/2574>`_.
     """
     set_up_module()
-    if not selectors.bug_is_fixed(2574, config.get_config()):
+    if not selectors.bug_is_fixed(2574, config.get_config().pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2574')
 
 


### PR DESCRIPTION
`bug_is_fixed` function has the signature:

`def bug_is_fixed(bug_id, pulp_version):`

A PulpSmashConfig object was being passed to this function call. Update
to be a pulp_version.