### PR TITLE
Adding task information to output on assert failure

### DIFF
--- a/pulp_2_tests/tests/docker/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_sync_publish.py
@@ -378,7 +378,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         client.request_kwargs['url'] = self.adjust_url(
             client.request_kwargs['url']
         )
-        self.assertIn('fsLayers', response, 'The blob data doesn\'t exist')
+        self.assertIn('fsLayers', response, 'The blob data does not exist')
         for blob in response['fsLayers']:
             with self.subTest(blob=blob):
                 response = client.get(

--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
@@ -359,8 +359,8 @@ class PulpManifestTestCase(BaseAPITestCase):
         # eval. Having this as a Python object helps inspecting the message
         description = json.loads(
             task['error']['description']
-            .replace('u\'', '\'')
-            .replace('\'', '"')
+            .replace('u\'', '\'')  # noqa
+            .replace('\'', '"')  # noqa
         )
         for info in description:
             with self.subTest(name=info['name']):

--- a/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
@@ -153,7 +153,7 @@ class SyncRpmRepoTestCase(SyncRepoBaseTestCase):
             self.assertEqual(len(tasks), 1)
         for count_type in ('added_count', 'removed_count', 'updated_count'):
             with self.subTest(comment=count_type):
-                self.assertEqual(tasks[0]['result'][count_type], 0)
+                self.assertEqual(tasks[0]['result'][count_type], 0, tasks)
 
 
 class SyncDrpmRepoTestCase(SyncRepoBaseTestCase):


### PR DESCRIPTION
## Problem

Redmine issue 4795 noted a possible failure in this test if the polling interval
to the Pulp2 API was too fast. This failure result caused invalid values to be populated
in the task details causing this test to fail.

## Change for Additional Troubleshooting
Adding the output of the tasks variable to the assert failure output to provide
additional troubleshooting information. This will include the full details response and
the task_id used in investigation.

## Sample Improved Output

```
___________________________ SyncRpmRepoTestCase.test_no_change_in_second_sync ___________________________

self = <pulp_2_tests.tests.rpm.api_v2.test_sync_publish.SyncRpmRepoTestCase testMethod=test_no_change_in_second_sync>

    def test_no_change_in_second_sync(self):
        """Verify that syncing a second time has no changes.
    
        If the repository have not changed then Pulp must state that anything
        was changed when doing a second sync.
        """
        report = sync_repo(self.cfg, self.repo)
        tasks = tuple(api.poll_spawned_tasks(self.cfg, report.json()))
        with self.subTest(comment='spawned tasks'):
            self.assertEqual(len(tasks), 1)
        for count_type in ('added_count', 'removed_count', 'updated_count'):
            with self.subTest(comment=count_type):
>               self.assertEqual(tasks[0]['result'][count_type], 0, tasks)
E               AssertionError: 8 != 0 : ({'exception': None, 'task_type': 'pulp.server.managers.repo.sync.sync', '_href': '/pulp/api/v2/tasks/145a83ed-6a9e-4333-aaee-5b65fc8ae94c/', 'task_id': '145a83ed-6a9e-4333-aaee-5b65fc8ae94c', 'tags': ['pulp:repository:bb6adde3-049f-4d62-aca4-16216c3a5065', 'pulp:action:sync'], 'finish_time': '2019-05-15T12:41:33Z', '_ns': 'task_status', 'start_time': '2019-05-15T12:41:26Z', 'traceback': None, 'spawned_tasks': [], 'progress_report': {'yum_importer': {'content': {'items_total': 0, 'state': 'FINISHED', 'error_details': [], 'details': {'rpm_total': 0, 'rpm_done': 0, 'drpm_total': 0, 'drpm_done': 0}, 'size_total': 0, 'size_left': 0, 'items_left': 0}, 'comps': {'state': 'FINISHED'}, 'purge_duplicates': {'state': 'FINISHED'}, 'distribution': {'items_total': 0, 'state': 'FINISHED', 'error_details': [], 'items_left': 0}, 'modules': {'state': 'FINISHED'}, 'errata': {'state': 'FINISHED'}, 'metadata': {'state': 'FINISHED'}}}, 'queue': 'reserved_resource_worker-0@rhel76-kersom.dq2', 'state': 'finished', 'worker_name': 'reserved_resource_worker-0@rhel76-kersom', 'result': {'result': 'success', 'importer_id': 'yum_importer', 'exception': None, 'repo_id': 'bb6adde3-049f-4d62-aca4-16216c3a5065', 'traceback': None, 'started': '2019-05-15T12:41:26Z', '_ns': 'repo_sync_results', 'completed': '2019-05-15T12:41:33Z', 'importer_type_id': 'yum_importer', 'error_message': None, 'summary': {'modules': {'state': 'FINISHED'}, 'content': {'state': 'FINISHED'}, 'comps': {'state': 'FINISHED'}, 'purge_duplicates': {'state': 'FINISHED'}, 'distribution': {'state': 'FINISHED'}, 'errata': {'state': 'FINISHED'}, 'metadata': {'state': 'FINISHED'}}, 'added_count': 8, 'removed_count': -8, 'updated_count': 0, 'id': '5cdc08fdb36cfb30a6ba9df3', 'details': {'modules': {'state': 'FINISHED'}, 'content': {'size_total': 0, 'items_left': 0, 'items_total': 0, 'state': 'FINISHED', 'size_left': 0, 'details': {'rpm_total': 0, 'rpm_done': 0, 'drpm_total': 0, 'drpm_done': 0}, 'error_details': []}, 'comps': {'state': 'FINISHED'}, 'purge_duplicates': {'state': 'FINISHED'}, 'distribution': {'items_total': 0, 'state': 'FINISHED', 'error_details': [], 'items_left': 0}, 'errata': {'state': 'FINISHED'}, 'metadata': {'state': 'FINISHED'}}}, 'error': None, '_id': {'$oid': '5cdc08f626f524775eff8d4c'}, 'id': '5cdc08f626f524775eff8d4c'},)

test_sync_publish.py:156: AssertionError
================================= 1 failed, 2 warnings in 17.02 seconds =================================
```
## References
* https://pulp.plan.io/issues/4795
* https://github.com/PulpQE/pulp-smash/pull/1207/files

## Linting Updates
Linters were updated from the time this commit work started.

Files added to PR to fix linting failures in TravisCI. Re-tested locally without failure:

### Lint Changes

* test_iso_crud: Just `# noqa` this change as it was a regular expression
* test_get_crane_repositories: Changed the optional message output of the assert to not include the contraction.
