### PR TITLE
Adding sudo to the find command for zchunk testing

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_sync_publish.py
@@ -600,7 +600,7 @@ class SyncZchunkRepoSkipTestCase(unittest.TestCase):
                 'f',
                 '-name',
                 '*.zck'
-            )).stdout.splitlines())
+            ), sudo=True).stdout.splitlines())
 
         # Verify other content units were copied
         copied_unit_ids = [


### PR DESCRIPTION
## Problem

Nightly CI was failing on the find command with the privileged user in zchunk testing. 

## Solution

Adding sudo.

## Testing

* Added the local ~/.ssh/config user as `jenkins` to replicate the problem
* Tested with/without the addition of `sudo` to verify the fix. 