### PR TITLE
Commenting out test_iso_crud::ISOUpdateTestCase until 4857 is resolved

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
@@ -401,7 +401,7 @@ class ISOUpdateTestCase(unittest.TestCase):
            changed.
         """
         cfg = config.get_config()
-        for issue_id in (2773, 3047, 3100):
+        for issue_id in (2773, 3047, 3100, 4857):
             if not selectors.bug_is_fixed(issue_id, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/' + str(issue_id))
 


### PR DESCRIPTION
## Problem

There was an implementation in #4807 that changed the expected behavior
being observed in  test_iso_crud::ISOUpdateTestCase.

## Solution

Commenting out for the time being while the issue is resolved.