### PR TITLE
Adding #4865 to blocking issues for test_iso_crud

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_iso_crud.py
@@ -401,7 +401,7 @@ class ISOUpdateTestCase(unittest.TestCase):
            changed.
         """
         cfg = config.get_config()
-        for issue_id in (2773, 3047, 3100, 4857):
+        for issue_id in (2773, 3047, 3100, 4857, 4865):
             if not selectors.bug_is_fixed(issue_id, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/' + str(issue_id))
 


### PR DESCRIPTION
## Problem

An external merged issue affected functionality of this test reported
in #4857. This issue was marked duplicate to the later #4865. 

## Solution 
Adding the ``parent`` issue to not affect test functionality and historic
information.

## References
See: https://pulp.plan.io/issues/4865