### PR TITLE
Removing docker v1 tests from repo

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -51,12 +51,6 @@ One can get a high-level view of the content in this repository by executing:
     | python -m json.tool
 """
 
-DOCKER_V1_FEED_URL = 'https://index.docker.io'
-"""The URL to a V1 Docker registry.
-
-This URL can be used as the "feed" property of a Pulp Docker registry.
-"""
-
 DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
 """The URL to a V2 Docker registry.
 

--- a/pulp_2_tests/tests/docker/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_copy.py
@@ -7,63 +7,10 @@ from pulp_smash import api, config, selectors
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import search_units, sync_repo
 
-from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_2_tests.constants import DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import get_upstream_name, skip_if
 from pulp_2_tests.tests.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-
-
-class CopyV1ContentTestCase(unittest.TestCase):
-    """Copy data between Docker repositories with schema v1 content."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create class-wide variables."""
-        super().setUpClass()
-        cls.cfg = config.get_config()
-        cls.repo = {}
-        cls.client = api.Client(cls.cfg, api.json_handler)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up resources."""
-        if cls.repo:
-            api.Client(cls.cfg).delete(cls.repo['_href'])
-        super().tearDownClass()
-
-    def test_01_set_up(self):
-        """Create a repository and populate with with schema v1 content."""
-        body = gen_repo()
-        body['importer_config'].update({
-            'enable_v1': True,
-            'enable_v2': False,
-            'feed': DOCKER_V1_FEED_URL,
-            'upstream_name': get_upstream_name(self.cfg),
-        })
-        type(self).repo = self.client.post(REPOSITORY_PATH, body)
-        sync_repo(self.cfg, self.repo)
-        type(self).repo = self.client.get(
-            self.repo['_href'],
-            params={'details': True}
-        )
-
-    @skip_if(bool, 'repo', False)
-    def test_02_copy_images(self):
-        """Copy tags from one repository to another.
-
-        Assert the same number of images are present in both repositories.
-        """
-        repo = self.client.post(REPOSITORY_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['_href'])
-        self.client.post(urljoin(repo['_href'], 'actions/associate/'), {
-            'source_repo_id': self.repo['id'],
-            'criteria': {'filters': {}, 'type_ids': ['docker_image']},
-        })
-        repo = self.client.get(repo['_href'], params={'details': True})
-        self.assertEqual(
-            self.repo['content_unit_counts']['docker_image'],
-            repo['content_unit_counts'].get('docker_image', 0),
-        )
 
 
 class CopyV2ContentTestCase(unittest.TestCase):

--- a/pulp_2_tests/tests/docker/api_v2/test_tags.py
+++ b/pulp_2_tests/tests/docker/api_v2/test_tags.py
@@ -11,7 +11,7 @@ from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp2.constants import CONTENT_UPLOAD_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import BaseAPITestCase, search_units, sync_repo
 
-from pulp_2_tests.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_2_tests.constants import DOCKER_V2_FEED_URL
 from pulp_2_tests.tests.docker.api_v2.utils import gen_repo
 from pulp_2_tests.tests.docker.utils import get_upstream_name, set_up_module
 
@@ -23,7 +23,7 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('These tests require at least Pulp 2.12.')
 
 
-def create_docker_repo(cfg, upstream_name, use_v1=False):
+def create_docker_repo(cfg, upstream_name):
     """Create a docker repository.
 
     :param cfg: Information about a Pulp
@@ -34,15 +34,9 @@ def create_docker_repo(cfg, upstream_name, use_v1=False):
     :return: Detailed information about the created repository.
     """
     body = gen_repo()
-    if use_v1:
-        body['importer_config'].update({
-            'enable_v1': True,
-            'feed': DOCKER_V1_FEED_URL,
-        })
-    else:
-        body['importer_config'].update({
-            'feed': DOCKER_V2_FEED_URL,
-        })
+    body['importer_config'].update({
+        'feed': DOCKER_V2_FEED_URL,
+    })
     body['importer_config']['upstream_name'] = upstream_name
     client = api.Client(cfg, api.json_handler)
     return client.post(REPOSITORY_PATH, body)


### PR DESCRIPTION
## Problem

Per the following pulp_docker PR, docker v1 is now depreciated and no longer supported:
* https://github.com/pulp/pulp_docker/pull/348

Failures were seen in docker v1 in CI. 

## Solution

Decided to go ahead and remove the v1 tests in the deprecation period.

## References
* https://pulp.plan.io/issues/4941
* https://pulp.plan.io/issues/4597


## Additional Note

There was a NOFIX issue in ``_do_test_invalid_upstream_name`` for DOCKER V2.

Went ahead and removed this case as the test is always skipped and the issue is already determined as NOFIX


Closes #4941