### PR TITLE
Adding additional modular copy permutations for libsolv regression

### DIFF
--- a/pulp_2_tests/constants.py
+++ b/pulp_2_tests/constants.py
@@ -169,18 +169,6 @@ MODULE_DATA_2 = MappingProxyType({
 })
 """A custom module information."""
 
-MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
-    'name': 'walrus',
-    'stream': '0.71',
-    'new_stream': '5.21',
-    'rpm_count': 4,
-    'total_available_units': 5,
-    'module_defaults': 3,
-})
-"""The name and the stream of the package listed in `modules.yaml`_.
-
-.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
-"""
 
 MODULE_ARTIFACT_RPM_DATA = MappingProxyType({
     'name': 'walrus',
@@ -696,6 +684,12 @@ RPM_WITH_OLD_VERSION_URL = urljoin(
 )
 """walrus RPM package has 2 versions. The URL to the older version."""
 
+RPM_WITH_OLD_VERSION_DUCK_URL = urljoin(
+    RPM_UNSIGNED_FEED_URL,
+    'duck-0.7-1.noarch.rpm'
+)
+"""duck RPM package has 4 versions. The URL to an older version."""
+
 RPM_ZCHUNK_FEED_COUNT = 35
 """The number of packages available at :data:`RPM_ZCHUNK_FEED_URL`."""
 
@@ -766,4 +760,64 @@ RPM_YUM_METADATA_FILE = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/tes
 
 .. _pulp-fixtures:
     https://repos.fedorapeople.org/pulp/pulp/fixtures/
+"""
+
+MODULE_FIXTURES_PACKAGE_STREAM = MappingProxyType({
+    'name': 'walrus',
+    'stream': '0.71',
+    'new_stream': '5.21',
+    'rpm_count': 4,
+    'total_available_units': 5,
+    'module_defaults': 3,
+    'feed': RPM_WITH_MODULES_FEED_URL,
+    'old': RPM_WITH_OLD_VERSION_URL,
+})
+"""The name and the stream of the package listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
+"""
+
+MODULE_FIXTURES_DUCK_4_STREAM = MappingProxyType({
+    'name': 'duck',
+    'stream': '4',
+    'new_stream': '4',
+    'rpm_count': 1,
+    'total_available_units': 2,
+    'module_defaults': 1,
+    'feed': RPM_WITH_MODULES_FEED_URL,
+    'old': RPM_WITH_OLD_VERSION_DUCK_URL,
+})
+"""The name and the stream of the package listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
+"""
+
+MODULE_FIXTURES_DUCK_5_STREAM = MappingProxyType({
+    'name': 'duck',
+    'stream': '5',
+    'new_stream': '5',
+    'rpm_count': 1,
+    'total_available_units': 2,
+    'module_defaults': 1,
+    'feed': RPM_WITH_MODULES_FEED_URL,
+    'old': RPM_WITH_OLD_VERSION_DUCK_URL,
+})
+"""The name and the stream of the package listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
+"""
+
+MODULE_FIXTURES_DUCK_6_STREAM = MappingProxyType({
+    'name': 'duck',
+    'stream': '6',
+    'new_stream': '6',
+    'rpm_count': 2,
+    'total_available_units': 3,
+    'module_defaults': 1,
+    'feed': RPM_WITH_MODULES_FEED_URL,
+    'old': RPM_WITH_OLD_VERSION_DUCK_URL,
+})
+"""The name and the stream of the package listed in `modules.yaml`_.
+
+.. _modules.yaml: https://github.com/PulpQE/pulp-fixtures/blob/master/rpm/assets/modules.yaml
 """


### PR DESCRIPTION
## Note

Dev PR 4962 is still outstanding. Therefore, this test will be skipped until then.

For development and early review, this PR/branch is posted.

* https://pulp.plan.io/issues/4962

## Problem

With the updated libsolv, the dependency solving on complex repositories was resulting in a regression of too many modules, modular RPMs, and ursine RPMs being copied.

## Solution 
This commit will do the following:
* Refactor the modular copy to allow for more modules
* Add a new module to check


## Additional Changes
* Moving the constants definitions further down the constants since variables need to be evaluated before the MODULE definitions

## OUTSTANDING FIXTURE UPDATE
The fixture this test is relying on was MANUALLY updated for this test:

* The fixture will need to be modified to have the modulemd patch applied that adds the new module definitions, duck, permanently. 

## How to Execute
To get the full effect and benefit of *subTest*, this test should be ran with *unittest* and not *pytest*.

### Run it all on a fixed dev branch

The full iteration suite is 371s.

* Iteration of just this class is with the additional module is 118s (~2mins).
* All tests should pass with a patch in place.
* With the current 2-master, there are 15 behavioral check failures that should be resolved.

### Code to Comment Out for Dev Run
To run with the extra modules on a dev branch, please comment out the following:
```
            if not selectors.bug_is_fixed(4962, cls.cfg.pulp_version):
                raise unittest.SkipTest('https://pulp.plan.io/issues/4962')
```

### Execution Command
From the Pulp-2-Test root directory:
```
time python -m unittest pulp_2_tests.tests.rpm.api_v2.test_modularity.CheckIsModularFlagTestCase -vvv
```

### Example Additional Verbose Output

The output of the specific failure does have to be mentally extrapolated a bit, but is available.

For example, the `check=(11,2)` failed, which from the output of `module` in the assert we can see that is `'total_available_units': 2,`. 

Therefore, the total units copied in `duck` was expected to be the module + duck RPM, but we got 11 units copied (bad).

```
======================================================================
FAIL: test_copy_modulemd_recursive_nonconservative_old_rpm (pulp_2_tests.tests.rpm.api_v2.test_modularity.CopyModulesTestCase) (check=(11, 2), modules='duck')
Test modular copy using override_config and old RPMs.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/herring/git/Pulp-2-Tests/pulp_2_tests/tests/rpm/api_v2/test_modularity.py", line 519, in check_module_rpm_total_units
    self.assertEqual(check[0], check[1], module)
AssertionError: 11 != 2 : {'name': 'duck', 'stream': '4', 'new_stream': '4', 'rpm_count': 1, 'total_available_units': 2, 'module_defaults': 1, 'feed': 'https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-test-modularity/', 'old': 'https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-unsigned/duck-0.7-1.noarch.rpm'}

----------------------------------------------------------------------
Ran 5 tests in 118.202s

FAILED (failures=15)

```

## References
* https://pulp.plan.io/issues/4962
* https://pulp.plan.io/issues/4995

closes #4955