### PR TITLE
Add pytest marker to tests related to recursive_conservative

### DIFF
--- a/pulp_2_tests/tests/rpm/api_v2/test_copy.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_copy.py
@@ -14,6 +14,7 @@ from pulp_smash.pulp2.utils import (
     sync_repo,
     upload_import_unit,
 )
+import pytest
 
 from pulp_2_tests.constants import (
     RPM_NAMESPACES,
@@ -33,6 +34,7 @@ from pulp_2_tests.tests.rpm.utils import set_up_module as setUpModule  # pylint:
 _PATH = '/var/lib/pulp/published/yum/https/repos/'
 
 
+@pytest.mark.recursive_conservative
 class CopyErrataRecursiveTestCase(unittest.TestCase):
     """Test that recursive copy of erratas copies RPM packages."""
 
@@ -145,6 +147,7 @@ class MtimeTestCase(unittest.TestCase):
         self.assertEqual(mtimes_pre, mtimes_post)
 
 
+@pytest.mark.recursive_conservative
 class CopyYumMetadataFileTestCase(unittest.TestCase):
     """Test the copy of metadata units between repos."""
 
@@ -234,6 +237,7 @@ class CopyYumMetadataFileTestCase(unittest.TestCase):
         self.assertGreater(len(yum_meta_data_element), 0)
 
 
+@pytest.mark.recursive_conservative
 class CopyConservativeTestCase(unittest.TestCase):
     """Test ``recursive`` and ``recursive_conservative`` flags during copy.
 

--- a/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_modularity.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from urllib.parse import urljoin
 from xml.etree import ElementTree
 
+import pytest
 from jsonschema import validate
 from packaging.version import Version
 
@@ -64,6 +65,9 @@ from pulp_2_tests.tests.rpm.utils import (
     gen_yum_config_file,
     os_support_modularity,
 )
+
+pytestmark = pytest.mark.recursive_conservative  # pylint:disable=invalid-name
+
 
 # MappingProxyType is used to make an immutable dict.
 MODULES_METADATA = MappingProxyType({

--- a/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
+++ b/pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py
@@ -3,6 +3,7 @@
 import unittest
 from urllib.parse import urljoin
 
+import pytest
 from packaging.version import Version
 from pulp_smash import api, cli, config, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
@@ -181,6 +182,7 @@ class SearchContentTestCase(unittest.TestCase):
                 self.assertEqual(result.stdout.count(field), 1, result)
 
 
+@pytest.mark.recursive_conservative
 class CopyRecursiveUnitsTestCase(unittest.TestCase):
     """Test copy units for a repository rich/weak dependencies.
 

--- a/pulp_2_tests/tests/rpm/cli/test_copy_units.py
+++ b/pulp_2_tests/tests/rpm/cli/test_copy_units.py
@@ -4,6 +4,7 @@ import subprocess
 import unittest
 from urllib.parse import urljoin
 
+import pytest
 from packaging.version import Version
 from pulp_smash import cli, config, selectors, utils
 from pulp_smash.pulp2.utils import pulp_admin_login
@@ -114,6 +115,7 @@ class CopyTestCase(UtilsMixin, unittest.TestCase):
         self.assertEqual(len(rpms['chimpanzee']), 1, rpms)
 
 
+@pytest.mark.recursive_conservative
 class CopyRecursiveTestCase(UtilsMixin, unittest.TestCase):
     """Recursively copy a "chimpanzee" unit from one repository to another.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    recursive_conservative: mark a test as part of the recursive_conservative feature.

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'packaging',
         'pulp-smash>=1!0.0.1,<1!1',
         'python-dateutil',
+        'pytest==4.1.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Add marker to certain tests related to recursive_conservative feature.
Once more tests are identified as part of this feature, this marker can
be applied.

This will allow run a subset of tests when like:

 pytest -v -m recursive_conservative

Moreover add pytest as dependency. Pin pytest version due to changes in
the order of tests running - mainly related to inheritance. Tests
inherinted from the
``BaseAPICrudTestCase`` are running the  ``BaseAPICrudTestCase`` as a
test itself. This behaviour is not observed in pytest version 4.1.0.

See: https://github.com/pulp/pulp-ci/pull/638