### PR TITLE
Update pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'packaging',
         'pulp-smash>=1!0.0.1,<1!1',
         'python-dateutil',
-        'pytest==4.1.0',
+        'pytest>4.2.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Pytest version was pinned previously due to an error. Pulp 2 tested with
the newest version of pytest. Error not raised again.

See: https://github.com/pulp/pulp-ci/pull/693