### PR TITLE
Add conftest.py to deselect baseclass to run

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Conftest file. Modifying test running activities."""
+
+
+def pytest_collection_modifyitems(items, config):
+    """Remove a certain class to run."""
+    deselected = []
+    for item in items:
+        if item.cls.__name__ == 'BaseAPICrudTestCase':
+            deselected.append(item)
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = [item for item in items if item not in deselected]


### PR DESCRIPTION
Add conftest.py to deselect base class BaseAPICrudTestCase to be detect
as a test to run.

See: https://github.com/PulpQE/Pulp-2-Tests/issues/77