### PR TITLE
Use pulp-smash from git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         'jsonschema',
         'packaging',
-        'pulp-smash>=1!0.0.1,<1!1',
+        'pulp-smash @ git+https://github.com/pulp/pulp-smash.git',
         'python-dateutil',
         'pytest==4.1.0',
     ],


### PR DESCRIPTION
Confirmed that this is installable with pulp-smash from git. Also, the
current version of pulp-smash is 1!0.13.0 and I don't think it'll ever
reach 1.0.0.